### PR TITLE
Don't run twice.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,6 @@ module.exports = function(grunt) {
 
     psc: {
       options: {
-        main: "Main",
         modules: ["Main"]
       },
       lib: {

--- a/dist/Main.js
+++ b/dist/Main.js
@@ -1909,4 +1909,3 @@ PS.Main = (function () {
         isForeignEntry: isForeignEntry
     };
 })();
-PS.Main.main();

--- a/index.html
+++ b/index.html
@@ -12,20 +12,20 @@
     </style>
     <script type="text/javascript" src="dist/Main.js"></script>
     <script type="text/javascript">
-      onload = PS.Main.main;     
+      this.onload = PS.Main.main;
     </script>
   </head>
   <body>
     <div class="container">
-        <h1>PURSuit</h1>   
+        <h1>PURSuit</h1>
 
-      <div class="well">    
+      <div class="well">
         <input type="search" class="form-control" id="searchInput" placeholder="Search..." autofocus />
       </div>
-      
+
       <div id="searchResults"></div>
 
       <div>&copy; Phil Freeman 2014 | <a href="http://github.com/purescript/pursuit">Source</a> | <a href="http://purescript.org">PureScript</a></div>
-    </div>	
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Since `dist/Main.js` already evaluates `PS.Main.main` the `onload` runs it again. The other option is to remove the `main` option in the grunt file. Not sure which one makes more sense here.
