### PR TITLE
Add purescript-free-canvas

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -96,6 +96,10 @@
     "github": { "user": "purescript", "repo": "purescript-free" }
   },
   {
+    "bowerName": "purescript-free-canvas",
+    "github": { "user": "paf31", "repo": "purescript-free-canvas" }
+  },
+  {
     "bowerName": "purescript-globals",
     "github": { "user": "purescript", "repo": "purescript-globals" }
   },


### PR DESCRIPTION
Not only is it a useful library, it also includes an exported type with
non-exported constructors - I want to make sure Pursuit handles this properly.