### PR TITLE
Link to packages

### DIFF
--- a/server/PursuitServer/HtmlTemplates.hs
+++ b/server/PursuitServer/HtmlTemplates.hs
@@ -2,6 +2,8 @@
 
 module PursuitServer.HtmlTemplates where
 
+import Prelude hiding (mod)
+
 import Lucid
 import qualified Data.Text as T
 
@@ -15,7 +17,7 @@ stylesheet url = link_ [href_ url, rel_ "stylesheet", type_ "text/css"]
 stylesheets :: [T.Text] -> Html ()
 stylesheets = mapM_ stylesheet
 
-index :: Maybe [Decl] -> Html ()
+index :: Maybe [DeclJ] -> Html ()
 index mDecls =
   doctypehtml_ $ do
     head_ $ do
@@ -42,18 +44,19 @@ index mDecls =
             " | "
             a_ [href_ "http://purescript.org"] "PureScript"
 
-renderDecls :: Maybe [Decl] -> Html ()
-renderDecls Nothing = p_ "Enter a search term above."
+renderDecls :: Maybe [DeclJ] -> Html ()
+renderDecls Nothing      = p_ "Enter a search term above."
+renderDecls (Just [])    = p_ "No results."
 renderDecls (Just decls) = mapM_ renderDecl decls
 
-renderDecl :: Decl -> Html ()
-renderDecl decl =
+renderDecl :: DeclJ -> Html ()
+renderDecl (decl, _, pkg) =
   div_ $ do
     h2_ (toHtml (declName decl))
     p_ $ code_ $ do
       toHtml modName
       " ("
-      toHtml pkgName
+      a_ [href_ (packageWebUrl pkg)] (toHtml pkgName)
       ")"
     toHtmlRaw (declDetail decl)
   where

--- a/server/PursuitServer/Server.hs
+++ b/server/PursuitServer/Server.hs
@@ -34,7 +34,7 @@ runServer (ServerOptions {..}) = do
       safeParam "q" >>= \case
         Just q -> do
           db <- liftIO $ readTVarIO dbvar
-          let result = queryDecls q db
+          let result = runQuery (queryDeclsJ q) db
           renderTemplate (index (Just result))
         _ ->
           renderTemplate (index Nothing)

--- a/src/Pursuit/Data.hs
+++ b/src/Pursuit/Data.hs
@@ -34,6 +34,7 @@ import Data.Aeson ((.:))
 import qualified Data.Aeson as A
 
 import qualified Data.Text.Lazy as TL
+import qualified Data.Text as T
 
 import qualified Lucid as L
 
@@ -96,8 +97,8 @@ data Package = Package { packageName    :: PackageName
 
 -- This will need to change if we decide to support packages which are not
 -- hosted on GitHub.
-packageWebUrl :: Package -> String
-packageWebUrl = toGitUrl . packageLocator
+packageWebUrl :: Package -> T.Text
+packageWebUrl = T.pack . toGitUrl . packageLocator
 
 -- A Module belongs to exactly one Package. The primary key is composite:
 -- (moduleName, modulePackageName)

--- a/src/Pursuit/Data.hs
+++ b/src/Pursuit/Data.hs
@@ -9,6 +9,8 @@ module Pursuit.Data (
   Decl(..),
   GitUrl(),
 
+  DeclJ(), ModuleJ(),
+
   PackageName(..), runPackageName, withPackageName,
   ModuleName(..),  runModuleName,  withModuleName,
   DeclName(..),    runDeclName,    withDeclName,
@@ -166,3 +168,9 @@ instance Indexable Decl where
                 , ixFun (singleton . lowerD . declName)
                 , ixFun (singleton . declDetail)
                 ]
+
+-- | "Decl-joined"; a Declaration, together with its parent Module and Package.
+type DeclJ = (Decl, Module, Package)
+
+-- | "Module-joined"; a Module, together with its parent Package.
+type ModuleJ = (Module, Package)

--- a/src/Pursuit/Data.hs
+++ b/src/Pursuit/Data.hs
@@ -2,7 +2,24 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 
-module Pursuit.Data where
+module Pursuit.Data (
+  PackageDesc(..),
+  Package(..),
+  Module(..),
+  Decl(..),
+  GitUrl(),
+
+  PackageName(..), runPackageName, withPackageName,
+  ModuleName(..),  runModuleName,  withModuleName,
+  DeclName(..),    runDeclName,    withDeclName,
+
+  Locator(..),
+  DeclDetail(..),
+
+  preludeWebUrl,
+  packageDescGitUrl,
+  packageWebUrl
+) where
 
 import Prelude hiding (mod)
 
@@ -90,8 +107,11 @@ data Module = Module { moduleName        :: ModuleName
 newtype ModuleName = ModuleName String
   deriving (Show, Eq, Ord, Typeable, L.ToHtml)
 
+runModuleName :: ModuleName -> String
+runModuleName (ModuleName n) = n
+
 withModuleName :: (String -> String) -> ModuleName -> ModuleName
-withModuleName f (ModuleName str) = ModuleName (f str)
+withModuleName f = ModuleName . f . runModuleName
 
 -- A Decl belongs to exactly one Module. The primary key is composite:
 -- (declName, declModule)
@@ -103,11 +123,15 @@ data Decl = Decl { declName   :: DeclName
 
 newtype DeclName = DeclName String
   deriving (Show, Eq, Ord, Typeable, L.ToHtml)
-newtype DeclDetail = DeclDetail TL.Text
-  deriving (Show, Eq, Ord, Typeable, L.ToHtml)
+
+runDeclName :: DeclName -> String
+runDeclName (DeclName n) = n
 
 withDeclName :: (String -> String) -> DeclName -> DeclName
 withDeclName f (DeclName str) = DeclName (f str)
+
+newtype DeclDetail = DeclDetail TL.Text
+  deriving (Show, Eq, Ord, Typeable, L.ToHtml)
 
 singleton :: a -> [a]
 singleton = (:[])

--- a/src/Pursuit/Data.hs
+++ b/src/Pursuit/Data.hs
@@ -138,34 +138,19 @@ newtype DeclDetail = DeclDetail TL.Text
 singleton :: a -> [a]
 singleton = (:[])
 
-lower :: String -> String
-lower = map toLower
-
-lowerP :: PackageName -> PackageName
-lowerP = withPackageName lower
-
-lowerM :: ModuleName -> ModuleName
-lowerM = withModuleName lower
-
-lowerD :: DeclName -> DeclName
-lowerD = withDeclName lower
-
 instance Indexable Package where
-  empty = ixSet [ ixFun (singleton . lowerP . packageName) ]
+  empty = ixSet [ ixFun (singleton . packageName) ]
 
 instance Indexable Module where
-  empty = ixSet [ ixFun (singleton . (lowerM . moduleName &&&
-                                      lowerP . modulePackageName))
-                , ixFun (singleton . lowerM . moduleName)
-                , ixFun (singleton . lowerP . modulePackageName)
+  empty = ixSet [ ixFun (singleton . (moduleName &&& modulePackageName))
+                , ixFun (singleton . moduleName)
+                , ixFun (singleton . modulePackageName)
                 ]
 
 instance Indexable Decl where
   empty = ixSet [ ixFun (\d -> let (mod, pkg) = declModule d
-                               in singleton (lowerD (declName d),
-                                             lowerM mod,
-                                             lowerP pkg))
-                , ixFun (singleton . lowerD . declName)
+                               in singleton (declName d, mod, pkg))
+                , ixFun (singleton . withDeclName (map toLower) . declName)
                 , ixFun (singleton . declDetail)
                 ]
 


### PR DESCRIPTION
Significant bits:

* `DeclJ` and `ModuleJ` types to represent the results of a join
* Indices have changed - only the DeclName index is lowercased now. The reason being that if a package contains two different modules with different capitalisation (yes, this is perverse, I know) the primary key should still distinguish them. And so on for the other indices.
* At the moment, if database constraints are violated (eg, orphaned Decls or Modules), we just fail to return anything. Perhaps we should be using EitherT rather than MaybeT? I'm not sure.

Come to think of it, perhaps the `createDatabase` function should check that there are no orphaned records...