### PR TITLE
don't immediately rebuild database

### DIFF
--- a/server/PursuitServer/Server.hs
+++ b/server/PursuitServer/Server.hs
@@ -79,4 +79,4 @@ startGenerateThread librariesFile = do
           else mapM_ (putStrLn . show) warnings
 
 hourly :: IO a -> IO a
-hourly action = forever (action >> threadDelay (3600 * 1000000))
+hourly action = forever (threadDelay (3600 * 1000000) >> action)


### PR DESCRIPTION
Currently, the following happens:

* Initial database build
* Start server
* Immediate database rebuild

This commit changes that so that after starting the server, the database
rebuild only happens after the time interval (currently 1 hour) has
elapsed.