### PR TITLE
Various improvements

### DIFF
--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -31,7 +31,8 @@ library
                    ixset -any,
                    blaze-html -any,
                    cheapskate -any,
-                   data-default -any
+                   data-default -any,
+                   github -any
     exposed-modules: Pursuit, Pursuit.Generator, Pursuit.Database, Pursuit.Data, Pursuit.Docs
     other-modules: Paths_pursuit
     buildable: True

--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -103,4 +103,5 @@ test-suite pursuit-tests
                       blaze-html -any,
                       cheapskate -any,
                       data-default -any,
-                      hspec -any
+                      hspec -any,
+                      github -any

--- a/src/Pursuit/Data.hs
+++ b/src/Pursuit/Data.hs
@@ -18,6 +18,8 @@ module Pursuit.Data (
   Locator(..),
   DeclDetail(..), runDeclDetail,
 
+  Item(..),
+
   preludeWebUrl,
   packageDescGitUrl,
   packageWebUrl
@@ -39,6 +41,8 @@ import qualified Lucid as L
 
 import Control.Arrow
 import Control.Applicative
+
+import qualified Language.PureScript as P
 
 -- This is what appears in the packages.json file
 data PackageDesc = PackageDesc { packageDescName    :: PackageName
@@ -137,6 +141,13 @@ newtype DeclDetail = DeclDetail TL.Text
 
 runDeclDetail :: DeclDetail -> TL.Text
 runDeclDetail (DeclDetail d) = d
+
+-- | An item to be included in the docs.
+data Item
+  = ItemDecl P.Declaration
+  -- | A data constructor, with a type name, constructor name, and constructor
+  -- arguments.
+  | ItemDataCtor (P.ProperName, P.ProperName, [P.Type])
 
 singleton :: a -> [a]
 singleton = (:[])

--- a/src/Pursuit/Docs.hs
+++ b/src/Pursuit/Docs.hs
@@ -23,8 +23,10 @@ import qualified Cheapskate
 
 import Pursuit.Data
 
-declarationDocs :: Maybe [P.DeclarationRef] -> P.Declaration -> TL.Text
-declarationDocs exps decl = H.renderHtml (renderDeclaration exps decl)
+declarationDocs :: Maybe [P.DeclarationRef] -> P.Declaration -> Maybe TL.Text
+declarationDocs exps decl = do
+  guard (P.isExported exps decl)
+  return $ H.renderHtml (renderDeclaration exps decl)
   where
   renderDeclaration :: Maybe [P.DeclarationRef] -> P.Declaration -> H.Html
   renderDeclaration _ (P.TypeDeclaration ident ty) =
@@ -245,8 +247,6 @@ dataConstructorDocs exps (tyName, ctorName, args) = do
   tyCtor :: P.Type
   tyCtor = P.TypeConstructor (P.Qualified Nothing tyName)
 
-      
-
 itemDocs :: Maybe [P.DeclarationRef] -> Item -> Maybe TL.Text
-itemDocs exps (ItemDecl d)     = Just (declarationDocs exps d)
+itemDocs exps (ItemDecl d)     = declarationDocs exps d
 itemDocs exps (ItemDataCtor c) = dataConstructorDocs exps c

--- a/src/Pursuit/Docs.hs
+++ b/src/Pursuit/Docs.hs
@@ -1,31 +1,17 @@
 {-# LANGUAGE OverloadedStrings, TemplateHaskell, TupleSections #-}
 
-module Pursuit.Docs (declarationDocs) where
+module Pursuit.Docs where
 
 import Control.Applicative
 import Control.Monad
-import Control.Monad.Writer
-import Control.Arrow (first)
 
-import Data.Ord (comparing)
-import Data.Char (toUpper)
 import Data.Default (def)
-import Data.List (nub, sortBy, intercalate)
-import Data.List.Split (splitOn)
 import Data.String (fromString)
-import Data.Maybe (fromMaybe, mapMaybe)
-import Data.Version (showVersion)
 import Data.Foldable (for_)
 
-import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
-import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as TL
 
-import qualified Data.Text.Lazy.IO as TL
-
 import qualified Language.PureScript as P
-import qualified Language.PureScript.Constants as C
 
 import Text.Blaze.Html ((!))
 import qualified Text.Blaze.Html as H
@@ -34,6 +20,8 @@ import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
 import qualified Cheapskate
+
+import Pursuit.Data
 
 declarationDocs :: Maybe [P.DeclarationRef] -> P.Declaration -> TL.Text
 declarationDocs exps decl = H.renderHtml (renderDeclaration exps decl)
@@ -116,125 +104,149 @@ declarationDocs exps decl = H.renderHtml (renderDeclaration exps decl)
     renderDeclaration exps d
     renderComments com
   renderDeclaration _ _ = return ()
-  
+
   renderComments :: [P.Comment] -> H.Html
   renderComments cs = do
     let raw = concatMap toLines cs
-    
+
     if all hasPipe raw
       then H.toHtml . Cheapskate.markdown def . fromString . unlines . map stripPipes $ raw
       else H.pre . H.code . H.toHtml $ unlines raw
     where
-  
+
     toLines (P.LineComment s) = [s]
     toLines (P.BlockComment s) = lines s
-    
+
     hasPipe s = case dropWhile (== ' ') s of { ('|':_) -> True; _ -> False }
-    
+
     stripPipes = dropPipe . dropWhile (== ' ')
-  
+
     dropPipe ('|':' ':s) = s
     dropPipe ('|':s) = s
     dropPipe s = s
-  
+
   toTypeVar :: (String, Maybe P.Kind) -> P.Type
   toTypeVar (s, Nothing) = P.TypeVar s
   toTypeVar (s, Just k) = P.KindedType (P.TypeVar s) k
-  
-  typeToHtml :: P.Type -> H.Html
-  typeToHtml = go 0 . P.everywhereOnTypes dePrim . P.everywhereOnTypesTopDown convertForAlls . P.everywhereOnTypes convert
+
+typeToHtml :: P.Type -> H.Html
+typeToHtml = go 0 . P.everywhereOnTypes dePrim . P.everywhereOnTypesTopDown convertForAlls . P.everywhereOnTypes convert
+  where
+  go :: Int -> P.Type -> H.Html
+  go _ P.TypeWildcard = withClass "syntax" (text "_")
+  go _ (P.TypeVar var) = withClass "ident" (text var)
+  go _ (P.PrettyPrintObject row) = do
+    withClass "syntax" (text "{") <* sp
+    rowToHtml row
+    sp *> withClass "syntax" (text "}")
+  go _ (P.PrettyPrintArray ty) = do
+    withClass "syntax" (text "[")
+    go 0 ty
+    withClass "syntax" (text "]")
+  go _ (P.TypeConstructor ctor@(P.Qualified _ name)) = H.a ! A.href (fromString ("/?q=" ++ show name)) $ withClass "ctor" (text (show name))
+  go n (P.ConstrainedType deps ty) = do
+    withClass "syntax" (text "(")
+    intercalateA_ (withClass "syntax" (text ",") <* sp) $ flip map deps $ \(pn, tys) -> do
+      let instApp = foldl P.TypeApp (P.TypeConstructor pn) tys
+      go 0 instApp
+    withClass "syntax" (text ")") *> sp
+    withClass "syntax" (text "=>") *> sp
+    go n ty
+  go _ P.REmpty = withClass "syntax" (text "()")
+  go _ row@P.RCons{} = do
+    withClass "syntax" (text "(")
+    rowToHtml row
+    withClass "syntax" (text ")")
+  go n (P.PrettyPrintFunction arg ret) | n < 1 = do
+    go (n + 1) arg *> sp
+    withClass "syntax" (text "->") *> sp
+    go 0 ret
+  go n (P.PrettyPrintForAll idents ty) | n < 1 = do
+    withClass "keyword" (text "forall") *> sp
+    intercalateA_ sp $ flip map idents $ withClass "ident" . text
+    withClass "syntax" (text ".") *> sp
+    go 0 ty
+  go n (P.TypeApp ty1 ty2) | n < 1 = do
+    go n ty1
+    sp
+    go (n + 1) ty2
+  go _ ty = do
+    withClass "syntax" (text "(")
+    go 0 ty
+    withClass "syntax" (text ")")
+
+  dePrim ty@(P.TypeConstructor (P.Qualified _ name))
+    | ty == P.tyBoolean || ty == P.tyNumber || ty == P.tyString =
+      P.TypeConstructor $ P.Qualified Nothing name
+  dePrim other = other
+
+  convert (P.TypeApp (P.TypeApp f arg) ret) | f == P.tyFunction = P.PrettyPrintFunction arg ret
+  convert (P.TypeApp a el) | a == P.tyArray = P.PrettyPrintArray el
+  convert (P.TypeApp o r) | o == P.tyObject = P.PrettyPrintObject r
+  convert other = other
+
+  convertForAlls (P.ForAll ident ty _) = go [ident] ty
     where
-    go :: Int -> P.Type -> H.Html
-    go _ P.TypeWildcard = withClass "syntax" (text "_")
-    go _ (P.TypeVar var) = withClass "ident" (text var)
-    go _ (P.PrettyPrintObject row) = do
-      withClass "syntax" (text "{") <* sp
-      rowToHtml row
-      sp *> withClass "syntax" (text "}")
-    go _ (P.PrettyPrintArray ty) = do
-      withClass "syntax" (text "[")
-      go 0 ty
-      withClass "syntax" (text "]")
-    go _ (P.TypeConstructor ctor@(P.Qualified _ name)) = H.a ! A.href (fromString ("/?q=" ++ show name)) $ withClass "ctor" (text (show name))
-    go n (P.ConstrainedType deps ty) = do
-      withClass "syntax" (text "(")
-      intercalateA_ (withClass "syntax" (text ",") <* sp) $ flip map deps $ \(pn, tys) -> do
-        let instApp = foldl P.TypeApp (P.TypeConstructor pn) tys
-        go 0 instApp
-      withClass "syntax" (text ")") *> sp
-      withClass "syntax" (text "=>") *> sp
-      go n ty
-    go _ P.REmpty = withClass "syntax" (text "()")
-    go _ row@P.RCons{} = do
-      withClass "syntax" (text "(")
-      rowToHtml row
-      withClass "syntax" (text ")")
-    go n (P.PrettyPrintFunction arg ret) | n < 1 = do
-      go (n + 1) arg *> sp
-      withClass "syntax" (text "->") *> sp
-      go 0 ret
-    go n (P.PrettyPrintForAll idents ty) | n < 1 = do
-      withClass "keyword" (text "forall") *> sp
-      intercalateA_ sp $ flip map idents $ withClass "ident" . text
-      withClass "syntax" (text ".") *> sp
-      go 0 ty
-    go n (P.TypeApp ty1 ty2) | n < 1 = do
-      go n ty1
-      sp
-      go (n + 1) ty2
-    go _ ty = do
-      withClass "syntax" (text "(")
-      go 0 ty
-      withClass "syntax" (text ")")
-  
-    dePrim ty@(P.TypeConstructor (P.Qualified _ name))
-      | ty == P.tyBoolean || ty == P.tyNumber || ty == P.tyString =
-        P.TypeConstructor $ P.Qualified Nothing name
-    dePrim other = other
-    
-    convert (P.TypeApp (P.TypeApp f arg) ret) | f == P.tyFunction = P.PrettyPrintFunction arg ret
-    convert (P.TypeApp a el) | a == P.tyArray = P.PrettyPrintArray el
-    convert (P.TypeApp o r) | o == P.tyObject = P.PrettyPrintObject r
-    convert other = other
-    
-    convertForAlls (P.ForAll ident ty _) = go [ident] ty
-      where
-      go idents (P.ForAll ident' ty' _) = go (ident' : idents) ty'
-      go idents other = P.PrettyPrintForAll idents other
-    convertForAlls other = other
-  
-  rowToHtml :: P.Type -> H.Html
-  rowToHtml = uncurry rowToHtml' . P.rowToList
-    where
-    rowToHtml' h t = do
-      headToHtml h
-      tailToHtml t    
-        
-    headToHtml = intercalateA_ (withClass "syntax" (text ",") <* sp) . map labelToHtml    
-        
-    labelToHtml (label, ty) = do
-      withClass "ident" (text label) <* sp
-      withClass "syntax" (text "::") <* sp
-      typeToHtml ty
-        
-    tailToHtml P.REmpty = return ()
-    tailToHtml other = do
-      sp *> withClass "syntax" (text "|") <* sp
-      typeToHtml other
+    go idents (P.ForAll ident' ty' _) = go (ident' : idents) ty'
+    go idents other = P.PrettyPrintForAll idents other
+  convertForAlls other = other
+
+rowToHtml :: P.Type -> H.Html
+rowToHtml = uncurry rowToHtml' . P.rowToList
+  where
+  rowToHtml' h t = do
+    headToHtml h
+    tailToHtml t
+
+  headToHtml = intercalateA_ (withClass "syntax" (text ",") <* sp) . map labelToHtml
+
+  labelToHtml (label, ty) = do
+    withClass "ident" (text label) <* sp
+    withClass "syntax" (text "::") <* sp
+    typeToHtml ty
+
+  tailToHtml P.REmpty = return ()
+  tailToHtml other = do
+    sp *> withClass "syntax" (text "|") <* sp
+    typeToHtml other
+
+text :: String -> H.Html
+text = H.toHtml
+
+sp :: H.Html
+sp = text " "
+
+withClass :: H.AttributeValue -> H.Html -> H.Html
+withClass className content = H.span ! A.class_ className $ content
+
+para :: H.AttributeValue -> H.Html -> H.Html
+para className content = H.p ! A.class_ className $ content
+
+intercalateA_ :: (Applicative m) => m b -> [m a] -> m ()
+intercalateA_ _   []     = pure ()
+intercalateA_ _   [x]    = void x
+intercalateA_ sep (x:xs) = (x <* sep) *> intercalateA_ sep xs
+
+dataConstructorDocs :: Maybe [P.DeclarationRef] -> (P.ProperName, P.ProperName, [P.Type]) -> Maybe TL.Text
+dataConstructorDocs exps (tyName, ctorName, args) = do
+  guard (P.isDctorExported tyName exps ctorName)
+  return $ H.renderHtml $ do
+    para "decl" $ H.code $ do
+      withClass "ident" . text . P.runProperName $ ctorName
+      sp *> withClass "syntax" (text "::") <* sp
+      typeToHtml fnType
+
+  where
+  fnType :: P.Type
+  fnType = if null args
+              then tyCtor
+              else foldr1 P.function (args ++ [tyCtor])
+
+  tyCtor :: P.Type
+  tyCtor = P.TypeConstructor (P.Qualified Nothing tyName)
+
       
-  text :: String -> H.Html
-  text = H.toHtml
-  
-  sp :: H.Html
-  sp = text " "
-  
-  withClass :: H.AttributeValue -> H.Html -> H.Html
-  withClass className content = H.span ! A.class_ className $ content
-  
-  para :: H.AttributeValue -> H.Html -> H.Html
-  para className content = H.p ! A.class_ className $ content
-  
-  intercalateA_ :: (Applicative m) => m b -> [m a] -> m ()
-  intercalateA_ _   []     = pure ()
-  intercalateA_ _   [x]    = void x
-  intercalateA_ sep (x:xs) = (x <* sep) *> intercalateA_ sep xs
+
+itemDocs :: Maybe [P.DeclarationRef] -> Item -> Maybe TL.Text
+itemDocs exps (ItemDecl d)     = Just (declarationDocs exps d)
+itemDocs exps (ItemDataCtor c) = dataConstructorDocs exps c

--- a/src/Pursuit/Docs.hs
+++ b/src/Pursuit/Docs.hs
@@ -53,7 +53,7 @@ declarationDocs exps decl = H.renderHtml (renderDeclaration exps decl)
     let typeApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
         exported = filter (P.isDctorExported name exps . fst) ctors
     para "decl" $ H.code $ do
-      withClass "keyword" . text $ show dtype  
+      withClass "keyword" . text $ show dtype
       sp
       typeToHtml typeApp
     unless (null exported) $ do
@@ -62,7 +62,7 @@ declarationDocs exps decl = H.renderHtml (renderDeclaration exps decl)
         typeToHtml typeApp
   renderDeclaration _ (P.ExternDataDeclaration name kind) = do
     para "decl" $ H.code $ do
-      withClass "keyword" . text $ "data"  
+      withClass "keyword" . text $ "data"
       sp
       typeToHtml $ P.TypeConstructor (P.Qualified Nothing name)
       sp *> withClass "syntax" (text "::") <* sp
@@ -70,7 +70,7 @@ declarationDocs exps decl = H.renderHtml (renderDeclaration exps decl)
   renderDeclaration _ (P.TypeSynonymDeclaration name args ty) = do
     let typeApp  = foldl P.TypeApp (P.TypeConstructor (P.Qualified Nothing name)) (map toTypeVar args)
     para "decl" $ H.code $ do
-      withClass "keyword" . text $ "type" 
+      withClass "keyword" . text $ "type"
       sp
       typeToHtml typeApp
       sp *> withClass "syntax" (text "=") <* sp

--- a/test/TestMain.hs
+++ b/test/TestMain.hs
@@ -32,7 +32,7 @@ main :: IO ()
 main = do
   db <- getDatabase
   let query q = runQuery (queryDeclsJ q) db
-  
+
   hspec $ do
     describe "ADTs" $ do
       describe "with non-exported data constructors" $ do
@@ -77,7 +77,7 @@ main = do
 
         thingy <- exactlyOne thingy'
         runDeclDetail (declDetail thingy) `shouldHaveSubstring` "(Thingy a) =>"
-    
+
     describe "Primitive types" $ do
       describe "should appear in the results" $ do
         forM_ ["Function", "String", "Number", "Array", "Object", "Boolean"] $ \prim -> do


### PR DESCRIPTION
* Partially switch to GitHub API rather than shelling out to git. This is just for retrieving tags, so far (refs #49)
* Include data constructors in the generated database
* Ensure only exported values are included (fixes #1)
* Fix some warnings in `Pursuit.Docs`