### PR TITLE
Fix prim docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,18 @@ getting your library included
 The Pursuit data is rebuilt daily by an automated job, so your library should
 appear within 24 hours. Any subsequent releases will automatically be shown on
 Pursuit, as long as you remember to `git tag` them.
+
+running pursuit
+---------------
+
+Pursuit uses the GitHub API for some of the information it needs, which means
+that it may come up against GitHub API rate limiting if no authentication is
+used.
+
+Pursuit supports GitHub API authentication via OAuth tokens; pass the token in
+via the environment variable `GITHUB_AUTH_TOKEN`. For example, if your auth
+token is stored in a file `.oauth_token`:
+
+```
+GITHUB_AUTH_TOKEN=`cat .oauth_token` cabal run
+```

--- a/prim/Prim.purs
+++ b/prim/Prim.purs
@@ -49,6 +49,7 @@ foreign import data Number :: *
 -- | Multi-line string literals are also supported with triple quotes (`"""`).
 foreign import data String :: *
 
--- | A JavaScript Boolean value. The Prelude exports the two values of this
--- | type: `true` and `false`.
+-- | A JavaScript Boolean value.
+-- |
+-- | Construct values of this type with the literals `true` and `false`.
 foreign import data Boolean :: *

--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -58,7 +58,8 @@ executable pursuit-server
                    lucid -any,
                    stm -any,
                    time -any,
-                   old-locale -any
+                   old-locale -any,
+                   github -any
     main-is: Main.hs
     buildable: True
     hs-source-dirs: server

--- a/server/PursuitServer/Types.hs
+++ b/server/PursuitServer/Types.hs
@@ -1,7 +1,8 @@
 module PursuitServer.Types where
 
 data ServerOptions = ServerOptions
-  { serverPort          :: Int
-  , serverLibrariesFile :: FilePath
+  { serverPort             :: Int
+  , serverLibrariesFile    :: FilePath
+  , serverGithubAuthToken  :: Maybe String
   }
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -18,7 +18,7 @@ testLibrariesFile = "./test/libraries-minimal.json"
 
 getDatabase :: IO PursuitDatabase
 getDatabase = do
-  (warns, _, eitherDb) <- generateDatabase testLibrariesFile
+  (warns, _, eitherDb) <- generateDatabase testLibrariesFile Nothing
 
   if (null warns)
     then putStrLn "Generated database. No warnings."


### PR DESCRIPTION
Make the docs say that `true` and `false` are literals, not exported by Prelude.

Please merge this after #74