### PR TITLE
Update LICENSE with instructions for relinking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,13 @@ install:
   - cabal install --only-dependencies --enable-tests --enable-benchmarks
 script:
   - cabal build
-after_script:
+notifications:
+  email: true
+before_deploy:
   - mkdir bundle
   - cp dist/build/pursuit/pursuit bundle/
   - cp LICENSE bundle/
   - tar czf pursuit.tar.gz -C bundle/ .
-notifications:
-  email: true
 deploy:
   provider: releases
   api_key: $RELEASE_KEY

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ install:
   - cabal --version
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - travis_retry cabal update
-  - cabal install --only-dependencies --enable-tests --enable-benchmarks
+  - cabal sandbox init
+  - cabal install --only-dependencies --enable-tests
 script:
   - cabal build
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 sudo: false
 before_install:
-  - export PATH="/opt/ghc/7.8.4/bin:/opt/cabal/1.22/bin:$HOME/.cabal/bin:$PATH"
+  - export PATH="/opt/ghc/7.8.4/bin:$PATH"
+  - export PATH="/opt/cabal/1.22/bin:$PATH"
+  - export PATH="$HOME/.cabal/bin:$PATH"
+  - export PATH="/opt/alex/3.1.4/bin:$PATH"
+  - export PATH="/opt/happy/1.19.5/bin:$PATH"
 install:
   - cabal --version
   - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
   - travis_retry cabal update
-  - cabal install alex happy
   - cabal install --only-dependencies --enable-tests --enable-benchmarks
 script:
   - cabal build
@@ -30,3 +33,8 @@ addons:
     packages:
       - cabal-install-1.22
       - ghc-7.8.4
+      - alex-3.1.4
+      - happy-1.19.5
+cache:
+  directories:
+    - .cabal-sandbox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,20 @@ install:
   - cabal install --only-dependencies --enable-tests --enable-benchmarks
 script:
   - cabal build
+after_script:
+  - mkdir bundle
+  - cp dist/build/pursuit/pursuit bundle/
+  - cp LICENSE bundle/
+  - tar czf pursuit.tar.gz -C bundle/ .
 notifications:
   email: true
+deploy:
+  provider: releases
+  api_key: $RELEASE_KEY
+  file: pursuit.tar.gz
+  skip_cleanup: true
+  on:
+    tags: true
 addons:
   apt:
     sources:

--- a/LICENSE
+++ b/LICENSE
@@ -19,6 +19,23 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+---
+
+Relinking with modified versions of LGPL v2.1 libraries
+
+Pursuit depends on some Haskell libraries which are LGPL v2.1 licensed. As per
+the terms of that license, we explain here how to compile a version of Pursuit
+using modified versions of these libraries.
+
+* Obtain the Pursuit source code: https://github.com/purescript/pursuit
+* Obtain the source code for the LGPL component, which is available from
+  Hackage, and make your desired modifications
+* Create a cabal sandbox
+* Use `cabal sandbox add-source` to use your modified version of the LGPL
+  component rather than the Hackage version.
+
+---
+
 Pursuit makes use of a number of libraries from Hackage. These libraries and
 their licenses are listed below:
 
@@ -9071,31 +9088,26 @@ x509-validation license file:
 
 xml-conduit license file:
 
-  The following license covers this documentation, and the source code, except
-  where otherwise indicated.
-  
   Copyright 2010, Suite Solutions. All rights reserved.
   
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions are met:
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of this software and associated documentation files (the
+  "Software"), to deal in the Software without restriction, including
+  without limitation the rights to use, copy, modify, merge, publish,
+  distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so, subject to
+  the following conditions:
   
-  * Redistributions of source code must retain the above copyright notice, this
-    list of conditions and the following disclaimer.
+  The above copyright notice and this permission notice shall be
+  included in all copies or substantial portions of the Software.
   
-  * Redistributions in binary form must reproduce the above copyright notice,
-    this list of conditions and the following disclaimer in the documentation
-    and/or other materials provided with the distribution.
-  
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS "AS IS" AND ANY EXPRESS OR
-  IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-  MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO
-  EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY DIRECT, INDIRECT,
-  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-  NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
-  OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-  OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
-  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+  NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+  LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 xml-types license file:
 

--- a/license-generator/header.txt
+++ b/license-generator/header.txt
@@ -19,5 +19,22 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+---
+
+Relinking with modified versions of LGPL v2.1 libraries
+
+Pursuit depends on some Haskell libraries which are LGPL v2.1 licensed. As per
+the terms of that license, we explain here how to compile a version of Pursuit
+using modified versions of these libraries.
+
+* Obtain the Pursuit source code: https://github.com/purescript/pursuit
+* Obtain the source code for the LGPL component, which is available from
+  Hackage, and make your desired modifications
+* Create a cabal sandbox
+* Use `cabal sandbox add-source` to use your modified version of the LGPL
+  component rather than the Hackage version.
+
+---
+
 Pursuit makes use of a number of libraries from Hackage. These libraries and
 their licenses are listed below:


### PR DESCRIPTION
... with modified versions of LGPL components, as per section 6a of the
LGPL v2.1

This should allow us to use Travis for building versions and publishing the results via GH releases.