### PR TITLE
Add note about --dry-run flag in help page

### DIFF
--- a/templates/help.hamlet
+++ b/templates/help.hamlet
@@ -19,27 +19,41 @@
     <h3>How to submit packages
     <ol>
       <li>
-        Put the code up on GitHub. (Currently, GitHub is the only supported hosting
-        method. If you'd rather host your code somewhere else, please open an issue
-        and let us know).
+        <p>
+          Put the code up on GitHub. (Currently, GitHub is the only supported hosting
+          method. If you'd rather host your code somewhere else, please open an issue
+          and let us know).
 
       <li>
-        Release your package on Bower, by using
-        <code>bower register#
-        \, creating a git tag, and pushing the tag to GitHub.
+        <p>
+          Ensure that your package is suitable for submission to Pursuit, by running
+          the following inside your project directory:
+        <pre>
+          <code>$ psc-publish --dry-run</code>
+        <p>
+          If <code>psc-publish</code> reports any errors, you should fix them before
+          continuing.
 
       <li>
-        Ensure that the tagged version is checked out, change to your project
-        directory, and run
-        <code>psc-publish > pursuit.json#
-        \. This will go through your bower.json file and all of your code,
-        collecting all of the information necessary to host your package on
-        Pursuit, and dump that data to a new file called pursuit.json.
+        <p>
+          Release your package on Bower, by using
+          <code>bower register#
+          \, creating a git tag, and pushing the tag to GitHub.
 
       <li>
-        Go to
-        <a href=@{UploadPackageR}>the upload page
-        and submit the pursuit.json file you just created.
+        <p>
+          Ensure that the tagged version is checked out, change to your project
+          directory, and run
+          <code>psc-publish > pursuit.json#
+          \. This will go through your bower.json file and all of your code,
+          collecting all of the information necessary to host your package on
+          Pursuit, and dump that data to a new file called pursuit.json.
+
+      <li>
+        <p>
+          Go to
+          <a href=@{UploadPackageR}>the upload page
+          and submit the pursuit.json file you just created.
     <p>
       Your package, together with documentation, should now appear in Pursuit.
 

--- a/templates/help.hamlet
+++ b/templates/help.hamlet
@@ -29,7 +29,7 @@
           Ensure that your package is suitable for submission to Pursuit, by running
           the following inside your project directory:
         <pre>
-          <code>$ psc-publish --dry-run</code>
+          <code>$ psc-publish --dry-run
         <p>
           If <code>psc-publish</code> reports any errors, you should fix them before
           continuing.
@@ -43,9 +43,11 @@
       <li>
         <p>
           Ensure that the tagged version is checked out, change to your project
-          directory, and run
-          <code>psc-publish > pursuit.json#
-          \. This will go through your bower.json file and all of your code,
+          directory, and run:
+        <pre>
+          <code>$ psc-publish > pursuit.json
+        <p>
+          This will go through your bower.json file and all of your code,
           collecting all of the information necessary to host your package on
           Pursuit, and dump that data to a new file called pursuit.json.
 


### PR DESCRIPTION
Fixes #142 

I also added paragraphs inside each `<li>`, which increases spacing between each item, making it easier to read. Without this, it would look very odd as the spacing between the `<pre>` and the paragrpah either side in the new item would be larger than the spacing between any two individual items.