### PR TITLE
Fix incorrect version sorting - #156

### DIFF
--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -37,7 +37,7 @@ getPackageAvailableVersionsR (PathPackageName pkgName) =
     let toPair v = [ toJSON $ showVersion v
                    , toJSON $ renderUrl $ alternateVersionUrl v
                    ]
-    return $ toJSON $ map toPair vs
+    return $ toJSON $ map toPair $ sort vs
   where
   alternateVersionUrl v = PackageVersionR (PathPackageName pkgName) (PathVersion v)
 

--- a/static/js/Pursuit.js
+++ b/static/js/Pursuit.js
@@ -40,7 +40,7 @@ function initializeVersionSelector(args) {
   // Returns an array of <option> elements which should be added to the version
   // selector. Warning: mutates the argument.
   function renderOptions(versions) {
-    versions.sort(function(x, y) { return x[0].localeCompare(y[0]) }).reverse()
+    versions.reverse()
     return versions.map(function(x, index) {
       if (index === 0) {
         return renderOption(function(str) { return "latest (" + str + ")" }, x)


### PR DESCRIPTION
Sort versions *before* `show`ing them, so that they get sorted as
versions, not as strings.