### PR TITLE
RESTful package list

### DIFF
--- a/src/Handler/Database.hs
+++ b/src/Handler/Database.hs
@@ -25,7 +25,7 @@ getAllPackageNames :: Handler [PackageName]
 getAllPackageNames = do
   dir <- getDataDir
   contents <- liftIO $ getDirectoryContents (dir ++ "/verified/")
-  return $ rights $ map mkPackageName contents
+  return . sort . rights $ map mkPackageName contents
 
 data SomethingMissing
   = NoSuchPackage


### PR DESCRIPTION
Add JSON and plain text representations available at /packages - Yesod chooses which to serve based on the Accept header.

@paf31 I wanted to get you to review this a) to see what you thought but also b) because I am fairly sure that it will require changes to the nginx configuration. At the moment I think nginx just tries to serve the first out of `index.{html,txt,json,svg}` that exists, and if none do, then it proxies to Yesod. With these changes, we would need to change it so that the Accept header is also checked in the nginx configuration, I think. I'm not exactly sure how it would look.