### PR TITLE
Distinguish package uploader and owner in UI

### DIFF
--- a/templates/packageVersion.hamlet
+++ b/templates/packageVersion.hamlet
@@ -7,8 +7,6 @@
   ^{versionSelector pkgName pkgVersion}
 
 <div .col.col-aside>
-  <p>published by #{linkToGithubUser pkgUploader}
-  <hr>
   <p>#{linkToGithub pkgGithub} on github
   <hr>
   $maybe licenses <- joinLicenses (bowerLicence pkgMeta)
@@ -25,6 +23,8 @@
             <a href=@{packageNameRoute depPkg}>#{runPackageName depPkg}
             #{renderVersionRange versionRange}
     <hr>
+  <p>uploaded by #{linkToGithubUser pkgUploader}
+  <hr>
 
 <div .col.col-main>
   $maybe readme <- mreadme


### PR DESCRIPTION
Makes the UI a bit less confusing. The uploader is not particularly
important info to most people browsing Pursuit, so we move that info to
the bottom. Also switch "published" for the less ambiguous "uploaded".