### PR TITLE
Fix Hoogle database generation errors

### DIFF
--- a/src/Model/DocsAsHoogle.hs
+++ b/src/Model/DocsAsHoogle.hs
@@ -66,9 +66,9 @@ qualifyConstructor ctx ctor' containMn =
     SameModule ->
       linkTitle
     LocalModule _ otherMn ->
-      show otherMn ++ "." ++ linkTitle
+      P.runModuleName otherMn ++ "." ++ linkTitle
     DepsModule _ _ _ otherMn ->
-      show otherMn ++ "." ++ linkTitle
+      P.runModuleName otherMn ++ "." ++ linkTitle
 
 declAsHoogle :: LinksContext' -> D.Declaration -> LT.Text
 declAsHoogle ctx d@D.Declaration{..} =


### PR DESCRIPTION
They were arising from the use of the Show ModuleName instance, which
previously was equivalent to the current runModuleName, but now is a
real Show instance.

Locally, using the most recent backup, this brings the number of Hoogle database regen errors from ~7000 down to 179. :smile: 