### PR TITLE
Fix a typo.

### DIFF
--- a/src/Handler/Hoogle.hs
+++ b/src/Handler/Hoogle.hs
@@ -181,7 +181,7 @@ extractHoogleResult tagStr url = do
          >>> reverse
          >>> splitAt 2
          >>> first parseTypeOrValue
-         >>> second ((decodeAnchorId >>> bracketOperators) >> Just)
+         >>> second (decodeAnchorId >>> bracketOperators >>> Just)
          >>> uncurry (liftA2 (,))
 
   bracketOperators str


### PR DESCRIPTION
(>>) is accidentally used where (>>>) is required. This small typo causes the
(decodeAnchorId >>> bracketOperators) to be skipped.