### PR TITLE
Update for PureScript 0.9.1

### DIFF
--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -85,7 +85,7 @@ library
                  , directory                     >= 1.1        && < 1.3
                  , warp                          >= 3.0        && < 4
                  , data-default
-                 , aeson                         >= 0.6        && < 0.10
+                 , aeson                         >= 0.11       && < 0.12
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4
                  , fast-logger                   >= 2.2        && < 2.5
@@ -96,7 +96,7 @@ library
                  , containers
                  , vector
                  , time
-                 , purescript >= 0.8.0
+                 , purescript >= 0.9.1
                  , bower-json >= 0.4
                  , lucid
                  , blaze-builder

--- a/src/Application.hs
+++ b/src/Application.hs
@@ -17,7 +17,7 @@ import "monad-logger" Control.Monad.Logger
   (liftLoc)
 import Language.Haskell.TH.Syntax
   (qLocation)
-import Control.Concurrent (threadDelay, forkIO)
+import Control.Concurrent (forkIO)
 import Network.Wai.Handler.Warp
   (Settings, defaultSettings, defaultShouldDisplayException, runSettings,
   setHost, setOnException, setPort, getPort)

--- a/src/Import/NoFoundation.hs
+++ b/src/Import/NoFoundation.hs
@@ -3,15 +3,10 @@ module Import.NoFoundation
     , module Import
     ) where
 
-import ClassyPrelude.Yesod   as Import hiding (intercalate)
+import ClassyPrelude.Yesod   as Import
 import Settings              as Import
 import Yesod.Core.Types      as Import (loggerSet)
 import Yesod.Default.Config2 as Import
 import Control.Category      as Import ((>>>), (<<<))
 
 type One = Succ Zero
-
--- This is a more useful way of defining intercalate, imo.
-intercalate :: (Monoid (Element seq), SemiSequence seq) =>
-  Element seq -> seq -> Element seq
-intercalate x xs = concat (intersperse x xs)

--- a/src/Model/DocsAsHtml.hs
+++ b/src/Model/DocsAsHtml.hs
@@ -131,7 +131,6 @@ declAsHtml r ctx d@Declaration{..} = do
       code_ [class_ "code-block"] $
         codeAsHtml r ctx (Render.renderDeclaration d)
 
-      for_ declFixity renderFixity
       for_ declComments renderComments
 
       let (instances, dctors, members) = partitionChildren declChildren
@@ -240,15 +239,6 @@ splitOnPathSep str
   | '/'  `elem` str = splitOn "/" str
   | '\\' `elem` str = splitOn "\\" str
   | otherwise       = [str]
-
-renderFixity :: P.Fixity -> Html ()
-renderFixity (P.Fixity associativity precedence) =
-  p_ (em_ (text (associativityStr <> " / precedence " <> show precedence)))
-  where
-  associativityStr = case associativity of
-    P.Infixl -> "left-associative"
-    P.Infixr -> "right-associative"
-    P.Infix  -> "non-associative"
 
 -- TODO: use GitHub API instead?
 renderComments :: String -> Html ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,12 +1,9 @@
-resolver: lts-5.12
+resolver: lts-6.1
 flags:
   pursuit:
     dev: true
 packages:
 - '.'
 extra-deps:
-- hjsmin-0.2.0.1
-- bower-json-0.8.0
-- purescript-0.8.5.0
-- language-javascript-0.6.0.4
+- purescript-0.9.1
 - wai-middleware-gunzip-0.0.2


### PR DESCRIPTION
I've tested this with `purescript-prelude`, `purescript-eff`, `purescript-console` and `purescript-psci-support` in `data/verified`. The only user-facing change is that operator fixity is not included in the text below an operator definition anymore, because it is now included in the definition itself. We could potentially do better at rendering operator aliases, but I'd say this isn't all bad either:
![bildschirmfoto am 2016-06-15 um 18 03 03](https://cloud.githubusercontent.com/assets/951129/16087873/f29eddf6-3324-11e6-8dc1-c2fc26583d15.png)
