### PR TITLE
Add type to search result

### DIFF
--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -70,8 +70,8 @@ data SearchResultInfo
   = PackageResult
   | ModuleResult String
   -- ^ Module name
-  | DeclarationResult TypeOrValue String String
-  -- ^ Module name & declaration title
+  | DeclarationResult TypeOrValue String String (Maybe String)
+  -- ^ Module name & declaration title & type if value
   deriving (Show, Eq, Generic)
 
 instance NFData SearchResultInfo
@@ -90,11 +90,12 @@ instance ToJSON SearchResultInfo where
       [ "type" .= ("module" :: Text)
       , "module" .= moduleName
       ]
-    DeclarationResult typeOrValue moduleName declTitle ->
+    DeclarationResult typeOrValue moduleName declTitle typeText ->
       [ "type" .= ("declaration" :: Text)
       , "typeOrValue" .= show typeOrValue
       , "module" .= moduleName
       , "title" .= declTitle
+      , "typeText" .= typeText
       ]
 
 -- | The foundation datatype for your application. This can be a good place to

--- a/src/Handler/Search.hs
+++ b/src/Handler/Search.hs
@@ -59,7 +59,7 @@ routeResult SearchResult{..} =
       ( PackageVersionModuleDocsR ppkgName pversion modName
       , Nothing
       )
-    DeclarationResult typeOrValue modName declTitle ->
+    DeclarationResult typeOrValue modName declTitle typeText ->
       ( PackageVersionModuleDocsR ppkgName pversion modName
       , Just $ pack $ drop 1 $ makeFragment typeOrValue declTitle
       )

--- a/templates/search.hamlet
+++ b/templates/search.hamlet
@@ -9,8 +9,12 @@
             <p>#{Bower.runPackageName $ hrPkgName r}
           $of ModuleResult moduleName
             <p>#{moduleName} (#{Bower.runPackageName $ hrPkgName r})
-          $of DeclarationResult _ _ name
+          $of DeclarationResult _ _ name typ
             <p>#{name}
+              $maybe typeValue <- typ
+                <small>
+                  <span> ::
+                  <code>#{typeValue}
 
         <p>
           <small>#{renderComments $ hrComments r}
@@ -20,6 +24,6 @@
             <p>
           $of ModuleResult _
             <p>
-          $of DeclarationResult _ modName _
+          $of DeclarationResult _ modName _ _
             <p>
               <small>#{modName} (#{Bower.runPackageName $ hrPkgName r})


### PR DESCRIPTION
Adding it to both the HTML output and particularly the JSON response.

As I understand it the JSON result used to contain the `identifier :: Type` as part of the `text` property (which right now seems to be a duplicate of `markup`), which was parsed out in the psc-ide-server https://github.com/purescript/purescript/blob/master/src/Language/PureScript/Ide/Types.hs#L228 - I figure an explicit field with the type is better. Probably this should also show the kind for types etc. And a better field name 