### PR TITLE
Use latest classy Prelude via extra-deps

### DIFF
--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -129,6 +129,8 @@ library
                  , xss-sanitize
                  , wai-middleware-gunzip
                  , barrier ==0.1.*
+                 , minlen
+                 , mono-traversable
 
     if flag(dev)
       build-depends: foreign-store

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -16,7 +16,6 @@ import Crypto.Random
 
 import Web.Bower.PackageMeta (PackageName, parsePackageName, runPackageName)
 import qualified Data.Trie as Trie
-import Control.DeepSeq (NFData, rnf)
 import Data.Version
 import Model.DocLinks (TypeOrValue(..))
 import qualified Css

--- a/src/Handler/Database.hs
+++ b/src/Handler/Database.hs
@@ -14,6 +14,7 @@ module Handler.Database
 import Import
 import qualified Data.Aeson as A
 import qualified Data.ByteString.Lazy as BL
+import qualified Data.MinLen as MinLen
 import qualified Data.Text as T
 import qualified Data.Trie as Trie
 import Data.Version (Version, showVersion)
@@ -29,6 +30,8 @@ import Language.PureScript.Docs.RenderedCode.Types (RenderedCodeElement(..), out
 
 import Handler.Utils
 import Handler.Caching (clearCache)
+
+type One = MinLen.Succ MinLen.Zero
 
 getAllPackageNames :: Handler [PackageName]
 getAllPackageNames = do
@@ -160,8 +163,8 @@ getPackageModificationTime pkgName = do
 getLatestVersionFor :: PackageName -> Handler (Maybe Version)
 getLatestVersionFor pkgName = do
   vs  <- availableVersionsFor pkgName
-  let vs' = toMinLen vs :: Maybe (MinLen One [Version])
-  return $ map maximum vs'
+  let vs' = MinLen.toMinLen vs :: Maybe (MinLen.MinLen One [Version])
+  return $ map MinLen.maximum vs'
 
 -- | Insert a package at a specific version into the database.
 insertPackage :: D.VerifiedPackage -> Handler ()

--- a/src/Import/NoFoundation.hs
+++ b/src/Import/NoFoundation.hs
@@ -1,12 +1,9 @@
 module Import.NoFoundation
-    ( module Import.NoFoundation
-    , module Import
+    ( module Import
     ) where
 
-import ClassyPrelude.Yesod   as Import
+import ClassyPrelude.Yesod   as Import hiding (Handler)
 import Settings              as Import
 import Yesod.Core.Types      as Import (loggerSet)
 import Yesod.Default.Config2 as Import
 import Control.Category      as Import ((>>>), (<<<))
-
-type One = Succ Zero

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,5 +5,13 @@ flags:
 packages:
 - '.'
 extra-deps:
+- chunked-data-0.3.0
+- classy-prelude-1.0.2
+- classy-prelude-conduit-1.0.2
+- classy-prelude-yesod-1.0.2
+- minlen-0.1.0.0
+- mono-traversable-1.0.1
+- mono-traversable-instances-0.1.0.0
+- say-0.1.0.0
 - purescript-0.9.3
 - wai-middleware-gunzip-0.0.2


### PR DESCRIPTION
This lets us use the same dependencies as we're using for the Nix build, which means we don't need to maintain a patch file for that deployment.

The `stack.yaml` file is a bit ugly right now, but I think we can update to LTS 7.12 as soon as `barrier` gets updated for GHC 8 (there is an open issue [here](https://github.com/philopon/barrier/issues/3))