### PR TITLE
Update LTS 7.12 -> 7.14

### DIFF
--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -104,7 +104,7 @@ library
                  , vector
                  , time
                  , purescript >= 0.9.1
-                 , bower-json >= 0.4
+                 , bower-json >= 0.8.1
                  , lucid
                  , blaze-builder
                  , blaze-markup

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -82,9 +82,6 @@ instance NFData SearchResultInfo
 
 -- Orphan instances which belong elsewhere
 
-instance NFData PackageName where
-  rnf _ = ()
-
 instance NFData P.Type where
   rnf _ = ()
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,10 @@
-resolver: lts-7.12
+resolver: lts-7.14
 flags:
   pursuit:
     dev: true
 packages:
 - '.'
 extra-deps:
-- wai-middleware-gunzip-0.0.2
 - barrier-0.1.1
 - purescript-0.10.3
+- wai-middleware-gunzip-0.0.2


### PR DESCRIPTION
bower-json now provides the NFData instance, so we can get rid of that,
which is nice.