### PR TITLE
UI Refinements

### DIFF
--- a/src/Css.hs
+++ b/src/Css.hs
@@ -92,3 +92,9 @@ codeForeground = fromRGB 25 74 91
 
 codeBackground :: HSV
 codeBackground = fromRGB 241 245 249
+
+lightGlyphColor :: HSV
+lightGlyphColor = fromRGB 160 160 160
+
+lightTypeColor :: HSV
+lightTypeColor = fromRGB 102 102 102

--- a/src/Css.hs
+++ b/src/Css.hs
@@ -75,6 +75,9 @@ darkForeground = fromRGB 240 240 240
 linkColor :: HSV
 linkColor = fromRGB 196 149 58
 
+linkActiveColor :: HSV
+linkActiveColor = fromRGB 123 89 4
+
 errorBackgroundColor :: HSV
 errorBackgroundColor = fromRGB 255 240 240
 

--- a/src/Css.hs
+++ b/src/Css.hs
@@ -81,9 +81,6 @@ errorBackgroundColor = fromRGB 255 240 240
 errorBorderColor :: HSV
 errorBorderColor = fromRGB 200 80 80
 
-successBackgroundColor :: HSV
-successBackgroundColor = fromRGB 150 240 150
-
 notAvailableBackgroundColor :: HSV
 notAvailableBackgroundColor = fromRGB 240 240 150
 

--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -212,13 +212,12 @@ documentationPage ::
 documentationPage pkg@D.Package{..} widget =
   let pkgName = D.packageName pkg
   in [whamlet|
-    <div .clearfix>
-      <div .col.col--main>
-        <h1>
-          package
-          <a href=@{packageRoute pkg}>#{runPackageName pkgName}
-
-      ^{versionSelector pkgName pkgVersion}
+    <div .page-title .clearfix>
+      <h1 .page-title__title>
+        <span .package-label>Package
+        <a href=@{packageRoute pkg}>#{runPackageName pkgName}
+      <div .page-title__version-selector>
+        ^{versionSelector pkgName pkgVersion}
 
     <div .col.col--main>
       ^{widget}

--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -163,10 +163,12 @@ getBuiltinDocsR mnString = do
         setTitle (toHtml mnString)
         let mn = P.moduleNameFromString mnString
         let htmlDocs = primDocs
-        let widget = $(widgetFile "packageVersionModuleDocs")
         [whamlet|
-          <div .col.col-main>
-            ^{widget}
+          <div .col.col--main>
+            <div .page-title.clearfix>
+              <div .page-title__label>Builtin
+              <h1 .page-title__title>#{insertBreaks mn}
+            #{htmlDocs}
           |]
     _ ->
       defaultLayout404 $ [whamlet|

--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -213,14 +213,14 @@ documentationPage pkg@D.Package{..} widget =
   let pkgName = D.packageName pkg
   in [whamlet|
     <div .clearfix>
-      <div .col.col-main>
+      <div .col.col--main>
         <h1>
           package
           <a href=@{packageRoute pkg}>#{runPackageName pkgName}
 
       ^{versionSelector pkgName pkgVersion}
 
-    <div .col.col-main>
+    <div .col.col--main>
       ^{widget}
     |]
 

--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -166,7 +166,7 @@ getBuiltinDocsR mnString = do
         [whamlet|
           <div .col.col--main>
             <div .page-title.clearfix>
-              <div .page-title__label>Builtin
+              <div .page-title__label>Module
               <h1 .page-title__title>#{insertBreaks mn}
             #{htmlDocs}
           |]

--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -213,8 +213,8 @@ documentationPage pkg@D.Package{..} widget =
   let pkgName = D.packageName pkg
   in [whamlet|
     <div .page-title .clearfix>
+      <div .page-title__label>Package
       <h1 .page-title__title>
-        <span .package-label>Package
         <a href=@{packageRoute pkg}>#{runPackageName pkgName}
       <div .page-title__version-selector>
         ^{versionSelector pkgName pkgVersion}

--- a/src/Model/DocsAsHtml.hs
+++ b/src/Model/DocsAsHtml.hs
@@ -177,8 +177,8 @@ declAsHtml r d@Declaration{..} = do
         renderChildren r instances
   where
     linkToSource :: HtmlRenderContext -> P.SourceSpan -> Html ()
-    linkToSource r srcspan =
-      span_ [class_ "decl__source"] (linkTo (renderSourceLink r srcspan) (text "Source"))
+    linkToSource ctx srcspan =
+      span_ [class_ "decl__source"] (linkTo (renderSourceLink ctx srcspan) (text "Source"))
 
 renderChildren :: HtmlRenderContext -> [ChildDeclaration] -> Html ()
 renderChildren _ [] = return ()

--- a/src/TemplateHelpers.hs
+++ b/src/TemplateHelpers.hs
@@ -105,18 +105,18 @@ renderReadme = \case
     html'
   Left APIRateLimited ->
     [shamlet|
-      <div .message .not-available>
+      <div .message .message--not-available>
         No readme available (due to rate limiting). Please try again later.
     |]
   Left ReadmeNotFound ->
     [shamlet|
-      <div .message .not-available>
+      <div .message .message--not-available>
         No readme found in the repository at this tag. If you are the maintainer,
         perhaps consider adding one in the next release.
     |]
   Left (OtherReason _) ->
     [shamlet|
-      <div .message .not-available>
+      <div .message .message--not-available>
         No readme available, for some unexpected reason (which has been logged).
         Perhaps
         <a href="https://github.com/purescript/pursuit/issues/new">

--- a/src/TemplateHelpers.hs
+++ b/src/TemplateHelpers.hs
@@ -31,7 +31,7 @@ linkToGithub (user, repo) =
 joinLicenses :: [Text] -> Maybe Html
 joinLicenses ls
   | null ls   = Nothing
-  | otherwise = Just (strong (toHtml (intercalate "/" ls)))
+  | otherwise = Just (toHtml (intercalate "/" ls))
 
 renderVersionRange :: Bower.VersionRange -> Html
 renderVersionRange = toHtml . Bower.runVersionRange
@@ -71,9 +71,10 @@ renderModuleList pkg = do
   moduleLinks <- traverse (linkToModule pkg . D.Local) moduleNames
 
   withUrlRenderer [hamlet|
-    <ul .documentation-contents>
+    <dl .grouped-list>
+      <dt .grouped-list__title>Modules
       $forall link <- moduleLinks
-        <li>#{link}
+        <dd .grouped-list__item>#{link}
     |]
 
 -- | Insert <wbr> elements in between elements of a module name, in order to

--- a/static/js/Pursuit.js
+++ b/static/js/Pursuit.js
@@ -92,7 +92,7 @@ function initializeUploadForm() {
 
     // remove previous error messages. Having one rendered by the server on the
     // page at the same time as one rendered client-side is a bit weird.
-    var errors = document.querySelectorAll('div.message.error')
+    var errors = document.querySelectorAll('div.message.message--error')
     Array.prototype.forEach.call(errors,
       function(el) {
         el.parentNode.removeChild(el)

--- a/templates/default-layout-wrapper.hamlet
+++ b/templates/default-layout-wrapper.hamlet
@@ -1,5 +1,5 @@
 $doctype 5
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/templates/default-layout-wrapper.hamlet
+++ b/templates/default-layout-wrapper.hamlet
@@ -6,7 +6,7 @@ $doctype 5
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>#{pageTitle'}
 
-    <link href="https://fonts.googleapis.com/css?family=Roboto:400,300,700" type="text/css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700,700i" type="text/css" rel="stylesheet">
     <link href=@{StaticR css_normalize_css} type="text/css" rel="stylesheet">
     <script type="text/javascript" src=@{StaticR js_js_cookie_js}>
     <script type="text/javascript" src=@{StaticR js_Markup_js}>

--- a/templates/default-layout.hamlet
+++ b/templates/default-layout.hamlet
@@ -11,7 +11,7 @@
 
       <form .top-banner__form role="search" action=@{SearchR} method="get">
         <label .hide-visually for="search-input">Search for packages, types, and functions
-        <input #search-input type="text" name="search-input" :isSearch:autofocus
+        <input #search-input type="text" name="q" :isSearch:autofocus
           data-focus-placeholder="Search for packages, functions …"
           data-normal-placeholder="Search for packages, functions … (S to focus)"
           placeholder="Search for packages, types, functions … (S to focus)"

--- a/templates/default-layout.hamlet
+++ b/templates/default-layout.hamlet
@@ -1,19 +1,21 @@
 <div .everything-except-footer>
   <div .top-banner .clearfix>
     <div .container .clearfix>
-      <div .banner-item .pursuit>
-        <a .pursuit href=@{HomeR}>Pursuit
+      <a .top-banner__logo href=@{HomeR}>Pursuit
 
-      <form .banner-item role="search" action=@{SearchR} method="get">
+      <div .top-banner__actions>
+        <div .top-banner__actions__item>
+          <a href=@{HelpR}>Help
+        <div .top-banner__actions__item>
+          <a href=@{UploadPackageR}>Publish
+
+      <form .top-banner__form role="search" action=@{SearchR} method="get">
         <label .hide-visually for="q">Search for packages, types, and functions
-        <input .form-control #search-input type="text" name="q" :isSearch:autofocus
-          data-focus-placeholder="Search for packages, functions..."
-          data-normal-placeholder="Search for packages, functions... (S to focus)"
-          placeholder="Search for packages, types, functions... (S to focus)"
+        <input #search-input type="text" name="q" :isSearch:autofocus
+          data-focus-placeholder="Search for packages, functions …"
+          data-normal-placeholder="Search for packages, functions … (S to focus)"
+          placeholder="Search for packages, types, functions … (S to focus)"
           value=#{searchText}>
-
-      <div .banner-item .upload>
-        <a href=@{UploadPackageR}>Upload
 
   <main .container .clearfix role="main">
     <div #message-container>

--- a/templates/default-layout.hamlet
+++ b/templates/default-layout.hamlet
@@ -5,7 +5,7 @@
         <a .pursuit href=@{HomeR}>Pursuit
 
       <form .banner-item role="search" action=@{SearchR} method="get">
-        <label .sr-only for="q">Search for packages, types, and functions
+        <label .hide-visually for="q">Search for packages, types, and functions
         <input .form-control #search-input type="text" name="q" :isSearch:autofocus
           data-focus-placeholder="Search for packages, functions..."
           data-normal-placeholder="Search for packages, functions... (S to focus)"

--- a/templates/default-layout.hamlet
+++ b/templates/default-layout.hamlet
@@ -10,8 +10,8 @@
           <a href=@{UploadPackageR}>Publish
 
       <form .top-banner__form role="search" action=@{SearchR} method="get">
-        <label .hide-visually for="q">Search for packages, types, and functions
-        <input #search-input type="text" name="q" :isSearch:autofocus
+        <label .hide-visually for="search-input">Search for packages, types, and functions
+        <input #search-input type="text" name="search-input" :isSearch:autofocus
           data-focus-placeholder="Search for packages, functions …"
           data-normal-placeholder="Search for packages, functions … (S to focus)"
           placeholder="Search for packages, types, functions … (S to focus)"

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -150,11 +150,6 @@ a:hover {
   text-decoration: underline;
 }
 
-a.weight-normal,
-a.weight-normal:hover {
-  font-weight: normal;
-}
-
 h1 {
   font-size: 3.814em;
   font-weight: 300;
@@ -410,9 +405,6 @@ p {
  * Font sizes are based on a major third scale (1:1.250)
  * ========================================================================== */
 
-a h2 { /* FIXME: target with class name instead */
-  margin-top: 0.83em;
-}
 
 ul {
   list-style-type: none;

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -462,7 +462,7 @@ ol li {
 
 .decl__body .keyword,
 .decl__body .syntax {
-  color: #a0a0a0;
+  color: #0B71B4;
 }
 
 

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -2,9 +2,7 @@
  * ========================================================================== */
 
 html {
-  overflow-y: scroll;
   box-sizing: border-box;
-  color: #000;
 }
 
 *, *:before, *:after {
@@ -13,6 +11,7 @@ html {
 
 body {
   background-color: #{Css.backgroundColor};
+  color: #000;
   font-family: "Roboto", sans-serif;
   line-height: 1.563em;
 }
@@ -31,7 +30,7 @@ body {
   clear: both;
 }
 
-/* Content hidden like will be read by a screen reader */
+/* Content hidden like this will still be read by a screen reader */
 .hide-visually {
   position: absolute;
   left: -10000px;
@@ -129,8 +128,8 @@ html, body {
  * ========================================================================== */
 
 :target {
-    border-radius: 5px;
-    background-color: #{Css.codeBackground};
+  background-color: #{Css.codeBackground};
+  border-radius: 5px;
 }
 
 a, a:visited {
@@ -148,6 +147,22 @@ a.weight-normal:hover {
   font-weight: normal;
 }
 
+h1 {
+  font-size: 3.814em;
+  font-weight: 300;
+  letter-spacing: -0.5px;
+  line-height: 1.125;
+}
+
+h2 {
+  font-size: 1.953em;
+  font-weight: normal;
+}
+
+h3 {
+  font-size: 1.563em;
+}
+
 hr {
   border: none;
   height: 1px;
@@ -156,6 +171,17 @@ hr {
 
 img {
   max-width: 100%;
+}
+
+p {
+  font-size: 1em;
+
+  /*
+  Useful for narrow screens, such as mobiles. Documentation often contains URLs
+  which would otherwise force the page to become wider, and force creation of
+  horizontal scrollbars. Yuck.
+  */
+  word-wrap: break-word;
 }
 
 
@@ -336,35 +362,8 @@ img {
  * Font sizes are based on a major third scale (1:1.250)
  * ========================================================================== */
 
-h1 {
-  font-size: 3.814em;
-  font-weight: 300;
-  letter-spacing: -0.5px;
-  line-height: 1.125;
-}
-
-h2 {
-  font-size: 1.953em;
-  font-weight: normal;
-}
-
-h3 {
-  font-size: 1.563em;
-}
-
 a h2 { /* FIXME: target with class name instead */
   margin-top: 0.83em;
-}
-
-p {
-  font-size: 1em;
-
-  /*
-  Useful for narrow screens, such as mobiles. Documentation often contains URLs
-  which would otherwise force the page to become wider, and force creation of
-  horizontal scrollbars. Yuck.
-  */
-  word-wrap: break-word;
 }
 
 ul {

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -1,3 +1,31 @@
+/** ************************************************************************* *
+ ** Pursuit CSS
+ **
+ ** This CSS file is structured into several sections, from general to
+ ** specific, and (mostly) alphabetically within the sections.
+ **
+ ** Several global element styles are used. This is not encouraged and should
+ ** be kept to a minimum. If you want to add new styles you'll most likely
+ ** want to add a new CSS component. See the Components section for examples.
+ **
+ ** CSS components use three simple naming ideas from the BEM system:
+ **   - Block:    `.my-component`
+ **   - Element:  `.my-component__item`
+ **   - Modifier: `.my-component.my-component--highlighted`
+ **
+ **   Example:
+ **   <div .my-component>
+ **     <div .my-component__item>
+ **     <div .my-component__item>
+ **   ...
+ **   <div .my-component.my-component--highlighted>
+ **     <div .my-component__item>
+ **     <div .my-component__item>
+ **
+ ** Components can be nested.
+ ** ************************************************************************* */
+
+
 /* Section: Document Styles
  * ========================================================================== */
 

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -569,8 +569,9 @@ ol li {
 .decl__source {
   display: block;
   float: right;
-  font-size: 1rem;
-  line-height: 2;
+  font-size: 64%;
+  position: relative;
+  top: 0.57em;
 }
 
 .decl__anchor, .decl__anchor:visited {

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -1,3 +1,6 @@
+/* Section: Document Styles
+ * ========================================================================== */
+
 html {
   overflow-y: scroll;
   box-sizing: border-box;
@@ -14,7 +17,10 @@ body {
   line-height: 1.563em;
 }
 
-/* Utility classes */
+
+/* Section: Utility Classes
+ * ========================================================================== */
+
 .clearfix:before,
 .clearfix:after {
   content: " ";
@@ -35,7 +41,10 @@ body {
   overflow: hidden;
 }
 
-/* Layout */
+
+/* Section: Layout
+ * ========================================================================== */
+
 .container {
   max-width: 1060px;
   margin-left: auto;
@@ -60,73 +69,35 @@ body {
   padding: 0 10px;
 }
 
-.top-banner .banner-item {
-  padding: 0 17px;
+@media (min-width: 50em) {
+  .col {
+    width: 70%
+  }
+
+  .col-single {
+    width: 100%;
+    margin-right: auto;
+    margin-left: auto;
+  }
 }
 
-h2.re-exports {
-  padding-top: 0.5em;
+@media (min-width: 70em) {
+  .col.col-main {
+    float: left;
+  }
+
+  .col.col-aside {
+    width: 30%;
+    float: right;
+  }
 }
 
-/* Links */
-a, a:visited {
-  color: #{Css.linkColor};
-  text-decoration: none;
-  font-weight: bold;
-}
 
-a.weight-normal,
-a.weight-normal:hover {
-  font-weight: normal;
-}
-
-a:hover {
-  text-decoration: underline;
-}
-
-/* Top banner */
-.top-banner,
-.top-banner a,
-.top-banner a:visited {
-  background-color: #{Css.bannerBackground};
-  color: #{Css.darkForeground};
-  text-decoration: none;
-  font-weight: lighter;
-  padding: 5px 0;
-}
-
-.top-banner a:hover {
-  background-color: #{Css.lighten10 Css.bannerBackground};
-}
-
-.top-banner {
-  line-height: 3.5em;
-  vertical-align: middle;
-}
-
-.top-banner .pursuit {
-  font-size: 150%;
-}
-
-.top-banner form {
-  color: #{Css.bannerBackground};
-}
-
-.top-banner input {
-  width: 100%;
-  line-height: 1.5em;
-  padding: 0.2em;
-  border-radius: 3px;
-}
-
-.top-banner .banner-item.upload {
-  font-size: 150%;
-}
-
-/* footer
+/* Footer
  * Based on http://www.lwis.net/journal/2008/02/08/pure-css-sticky-footer/
  * Except we don't support IE6
- */
+ * -------------------------------------------------------------------------- */
+
 html, body {
   height: 100%;
 }
@@ -150,7 +121,70 @@ html, body {
   margin-bottom: 0;
 }
 
-/* Messages */
+
+/* Section: Element Styles
+ *
+ * Have as few of these as possible and keep them general, because they will
+ * influence every component hereafter.
+ * ========================================================================== */
+
+:target {
+    border-radius: 5px;
+    background-color: #{Css.codeBackground};
+}
+
+a, a:visited {
+  color: #{Css.linkColor};
+  text-decoration: none;
+  font-weight: bold;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+a.weight-normal,
+a.weight-normal:hover {
+  font-weight: normal;
+}
+
+hr {
+  border: none;
+  height: 1px;
+  background-color: #{Css.darken20 Css.backgroundColor};
+}
+
+img {
+  max-width: 100%;
+}
+
+
+/* Section: Components
+ * ========================================================================== */
+
+/* Component: Dependency Link
+ * -------------------------------------------------------------------------- */
+
+.dependency-link {
+  display: inline-block;
+  margin-right: 0.41em;
+}
+
+
+/* Component: Dependency Version
+ * -------------------------------------------------------------------------- */
+
+.dependency-version {
+  color: #{Css.lightTypeColor};
+  display: inline-block;
+  font-size: 0.8em;
+  line-height: 1;
+}
+
+
+/* Component: Message
+ * -------------------------------------------------------------------------- */
+
 .message {
   border: 5px solid;
   border-radius: 5px;
@@ -172,10 +206,142 @@ html, body {
   border-color: #{Css.darken20 Css.notAvailableBackgroundColor};
 }
 
-/**
- * Typography
- * Font sizes are based on a major third scale (1:1.250)
+
+/* Component: Package Label
  * -------------------------------------------------------------------------- */
+
+.package-label {
+  color: #{Css.lightTypeColor};
+  display: block;
+  font-size: 0.8rem;
+  letter-spacing: 1px;
+  margin-bottom: -0.41em;
+  text-transform: uppercase;
+}
+
+
+/* Component: Top Banner
+ * -------------------------------------------------------------------------- */
+
+.top-banner {
+  background-color: #{Css.bannerBackground};
+  color: #{Css.darkForeground};
+  font-weight: lighter;
+  line-height: 3.5em;
+  padding: 5px 0;
+  text-decoration: none;
+  vertical-align: middle;
+}
+
+.top-banner a,
+.top-banner a:visited {
+  background-color: #{Css.bannerBackground};
+  color: #{Css.darkForeground};
+  text-decoration: none;
+  font-weight: lighter;
+  padding: 5px 0;
+}
+
+.top-banner a:hover {
+  background-color: #{Css.lighten10 Css.bannerBackground};
+}
+
+.top-banner .pursuit {
+  font-size: 150%;
+}
+
+.top-banner form {
+  color: #{Css.bannerBackground};
+}
+
+.top-banner input {
+  width: 100%;
+  line-height: 1.5em;
+  padding: 0.2em;
+  border-radius: 3px;
+}
+
+.top-banner .banner-item {
+  padding: 0 17px;
+}
+
+.top-banner .banner-item.upload {
+  font-size: 150%;
+}
+
+@media (min-width: 50em) {
+  .top-banner .banner-item {
+    float: left;
+  }
+
+  .top-banner .banner-item.pursuit {
+    margin-right: 3em;
+  }
+
+  .top-banner form.banner-item {
+    width: 50%;
+  }
+
+  .top-banner .banner-item.upload {
+    float: right;
+  }
+}
+
+
+/* Component: Search Results
+ * -------------------------------------------------------------------------- */
+
+.search-result {
+  display: block;
+  background: #{Css.codeBackground};
+  padding: 0.2em 1em;
+  margin-bottom: 1em;
+  color: #000;
+  font-weight: normal;
+  border: 1px solid #{Css.codeBackground};
+  border-radius: 5px;
+}
+
+.search-result .highlight {
+  color: #{Css.linkColor};
+}
+
+.search-result p:first-child {
+  margin-bottom: 0.5em;
+}
+
+.search-result p:nth-child(2) {
+  margin-top: 0.5em;
+}
+
+.search-result:hover,
+.search-result:focus {
+  text-decoration: none;
+  background: #{Css.lighten5 Css.codeBackground};
+  border: 1px solid #{Css.codeForeground};
+  outline: none;
+}
+
+
+/* Component: Version Selector
+ * -------------------------------------------------------------------------- */
+
+.version-selector {
+  float: left;
+  width: auto;
+  min-width: 20%;
+}
+
+@media (min-width: 70em) {
+  .version-selector {
+    margin-top: 1em;
+  }
+}
+
+
+/* Section: Typography
+ * Font sizes are based on a major third scale (1:1.250)
+ * ========================================================================== */
 
 h1 {
   font-size: 3.814em;
@@ -233,6 +399,12 @@ ol {
 ol li {
 }
 
+
+h2.re-exports {
+  padding-top: 0.5em;
+}
+
+
 /* Tables */
 table { /* FIXME: possibly wrap table in div */
   /* Seemingly necessary for the ".col table" rule above to work */
@@ -247,76 +419,10 @@ tbody tr:nth-child(odd) {
   background-color: #eee;
 }
 
-/* Images */
-img {
-  max-width: 100%;
-}
-
-/* Version selector */
-.version-selector {
-  float: left;
-  width: auto;
-  min-width: 20%;
-}
 
 /* GitHub rendered README */
 .entry-content p:first-child {
   margin-top: 0;
-}
-
-/* Search results */
-.search-result {
-  display: block;
-  background: #{Css.codeBackground};
-  padding: 0.2em 1em;
-  margin-bottom: 1em;
-  color: #000;
-  font-weight: normal;
-  border: 1px solid #{Css.codeBackground};
-  border-radius: 5px;
-}
-
-.search-result .highlight {
-  color: #{Css.linkColor};
-}
-
-.search-result p:first-child {
-  margin-bottom: 0.5em;
-}
-
-.search-result p:nth-child(2) {
-  margin-top: 0.5em;
-}
-
-.search-result:hover,
-.search-result:focus {
-  text-decoration: none;
-  background: #{Css.lighten5 Css.codeBackground};
-  border: 1px solid #{Css.codeForeground};
-  outline: none;
-}
-
-/* Dependencies */
-.dependency-link {
-  display: inline-block;
-  margin-right: 0.41em;
-}
-
-.dependency-version {
-  color: #{Css.lightTypeColor};
-  display: inline-block;
-  font-size: 0.8em;
-  line-height: 1;
-}
-
-/* Package label */
-.package-label {
-  color: #{Css.lightTypeColor};
-  display: block;
-  font-size: 0.8rem;
-  letter-spacing: 1px;
-  margin-bottom: -0.41em;
-  text-transform: uppercase;
 }
 
 /* Help paragraphs */
@@ -376,63 +482,10 @@ code, pre {
     padding-top: 0.4em;
 }
 
-:target {
-    border-radius: 5px;
-    background-color: #{Css.codeBackground};
-}
-
 .decl-inner {
     padding: 0 0.9em;
 }
 
 .documentation-contents li {
     font-size: 1.3em;
-}
-
-hr {
-  border: 1px solid #{Css.darken20 Css.backgroundColor};
-}
-
-/* media queries */
-@media (min-width: 50em) {
-  .col {
-    width: 70%
-  }
-
-  .col-single {
-    width: 100%;
-    margin-right: auto;
-    margin-left: auto;
-  }
-
-  .top-banner .banner-item {
-    float: left;
-  }
-
-  .top-banner .banner-item.pursuit {
-    margin-right: 3em;
-  }
-
-  .top-banner form.banner-item {
-    width: 50%;
-  }
-
-  .top-banner .banner-item.upload {
-    float: right;
-  }
-}
-
-@media (min-width: 70em) {
-  .col.col-main {
-    float: left;
-  }
-
-  .col.col-aside {
-    width: 30%;
-    float: right;
-  }
-
-  select.version-selector {
-    margin-top: 1em;
-  }
 }

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -27,6 +27,10 @@ body {
 /* Section: Utility Classes
  * ========================================================================== */
 
+.clear-floats {
+  clear: both;
+}
+
 .clearfix::before,
 .clearfix::after {
   content: " ";
@@ -82,14 +86,13 @@ body {
 
   .col.col--main {
     float: left;
-    width: 67%
+    width: 63.655%; /* 66.6…% - 30px */
   }
 
   .col.col--aside {
     float: right;
     font-size: 87.5%;
-    padding-left: 30px;
-    width: 33%;
+    width: 33.333333%;
   }
 }
 
@@ -218,12 +221,19 @@ pre code::after {
 }
 
 h1 {
-  font-size: 3.814em;
+  font-size: 3.052em;
   font-weight: 300;
   letter-spacing: -0.5px;
   line-height: 1.125;
-  margin-top: 5.96rem;
+  margin-top: 1.563rem;
   margin-bottom: 1.25rem;
+}
+
+@media (min-width: 52em) {
+  h1 {
+    font-size: 3.814em;
+    margin-top: 5.96rem;
+  }
 }
 
 h2 {
@@ -320,6 +330,13 @@ ul li::before {
   display: inline-block;
   margin-left: -1.250em;
   width: 1.250em;
+}
+
+/* Tying this tightly to ul at the moment because it's a slight variation thereof */
+ul.ul--search li::before {
+  content: "⚲";
+  top: -0.2em;
+  transform: rotate(-45deg);
 }
 
 ol {
@@ -478,6 +495,44 @@ ol li {
 .message.message--not-available {
   background-color: #{Css.notAvailableBackgroundColor};
   border-color: #{Css.darken20 Css.notAvailableBackgroundColor};
+}
+
+
+/* Component: Multi Col
+ * Multiple columns side by side
+ * -------------------------------------------------------------------------- */
+
+.multi-col {
+  margin-bottom: 2.44em;
+}
+
+.multi-col__col {
+  display: block;
+  padding-right: 1em;
+  position: relative;
+  width: 100%;
+}
+
+@media (min-width: 38em) and (max-width: 51.999999em) {
+  .multi-col__col {
+    float: left;
+    width: 50%;
+  }
+
+  .multi-col__col:nth-child(2n+3) {
+    clear: both;
+  }
+}
+
+@media (min-width: 52em) {
+  .multi-col__col {
+    float: left;
+    width: 33.333333%;
+  }
+
+  .multi-col__col:nth-child(3n+4) {
+    clear: both;
+  }
 }
 
 

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -147,7 +147,8 @@ a, a:visited {
 }
 
 a:hover {
-  text-decoration: underline;
+  color: #{Css.linkActiveColor};
+  text-decoration: none;
 }
 
 h1 {
@@ -296,7 +297,7 @@ p {
 }
 
 .top-banner__logo:hover {
-  color: #DCAB4E; /* FIXME: define color from color scheme */
+  color: #{Css.linkColor};
   text-decoration: none;
 }
 
@@ -328,6 +329,15 @@ p {
 
 .top-banner__actions__item:first-child {
   padding-left: 0;
+}
+
+.top-banner__actions__item a,
+.top-banner__actions__item a:visited {
+  color: #{Css.darkForeground}
+}
+
+.top-banner__actions__item a:hover {
+  color: #{Css.linkColor}
 }
 
 @media (min-width: 38em) {

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -14,7 +14,7 @@ body {
   color: #000;
   font-family: "Roboto", sans-serif;
   font-size: 87.5%;
-  line-height: 1.563em;
+  line-height: 1.563;
 }
 
 @media (min-width: 38em) {
@@ -213,21 +213,40 @@ h1 {
   font-weight: 300;
   letter-spacing: -0.5px;
   line-height: 1.125;
+  margin-top: 5.96rem;
+  margin-bottom: 1.25rem;
 }
 
 h2 {
   font-size: 1.953em;
   font-weight: normal;
+  line-height: 1.250;
+  margin-top: 3.052rem;
+  margin-bottom: 1rem;
 }
 
 h3 {
   font-size: 1.563em;
   font-weight: normal;
+  line-height: 1.250;
+  margin-top: 2.441rem;
+  margin-bottom: 1rem;
 }
 
 h4 {
   font-size: 1.25em;
   font-weight: normal;
+  margin-top: 2.441rem;
+  margin-bottom: 1rem;
+}
+
+h1 + h2,
+h1 + h3,
+h1 + h4,
+h2 + h3,
+h2 + h4,
+h3 + h4 {
+  margin-top: 1rem;
 }
 
 hr {
@@ -243,12 +262,16 @@ img {
 
 p {
   font-size: 1em;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
 }
 
 table {
   border-bottom: 1px solid #{Css.darken20 Css.backgroundColor};
   border-collapse: collapse;
   border-spacing: 0;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
   width: 100%;
 }
 
@@ -271,6 +294,8 @@ td:last-child, th:last-child {
 
 ul {
   list-style-type: none;
+  margin-top: 1rem;
+  margin-bottom: 1rem;
   padding-left: 0;
 }
 
@@ -289,6 +314,8 @@ ul li::before {
 }
 
 ol {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
   padding-left: 1.250em;
 }
 
@@ -536,7 +563,7 @@ ol li {
 .decl__title {
   position: relative;
   padding-bottom: 0.328em;
-  margin: 2.44em 0 0.262em 0;
+  margin-bottom: 0.262em;
 }
 
 .decl__source {

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -62,7 +62,16 @@ body {
 
 .col {
   display: block;
+  position: relative;
   width: 100%;
+}
+
+.col.col--main {
+  margin-bottom: 3.08em;
+}
+
+.col.col--aside {
+  margin-bottom: 2.44em;
 }
 
 @media (min-width: 52em) {
@@ -205,6 +214,28 @@ p {
 }
 
 
+/* Component: Grouped List
+ * -------------------------------------------------------------------------- */
+
+.grouped-list {
+  border-top: 1px solid #{Css.darken20 Css.backgroundColor};
+  margin: 0 0 2.44em 0;
+}
+
+.grouped-list__title {
+  color: #{Css.lightTypeColor};
+  font-size: 0.8em;
+  font-weight: 300;
+  letter-spacing: 1px;
+  margin: 0.8em 0 -0.1em 0;
+  text-transform: uppercase;
+}
+
+.grouped-list__item {
+  margin: 0;
+}
+
+
 /* Component: Message
  * -------------------------------------------------------------------------- */
 
@@ -229,29 +260,13 @@ p {
  * -------------------------------------------------------------------------- */
 
 .page-title {
-  border-bottom: 1px solid #{Css.darken20 Css.backgroundColor};
-  margin: 2.44em 0 3.05em;
+  margin: 4.77em 0 1.56em;
   padding-bottom: 1.25em;
   position: relative;
 }
 
 .page-title__title {
-  float: left;
   margin: 0;
-}
-
-.page-title__version-selector {
-  position: absolute;
-  top: -1em;
-  right: 0;
-}
-
-@media (min-width: 52em) {
-  .page-title__version-selector {
-    position: static;
-    float: right;
-    margin-top: 2.6em;
-  }
 }
 
 
@@ -374,7 +389,17 @@ p {
 /* Component: Version Selector
  * -------------------------------------------------------------------------- */
 
-.version-selector { /* No styles at the moment */ }
+.version-selector {
+  position: absolute;
+  top: 0.512em;
+  right: 0;
+}
+
+@media (min-width: 38em) {
+  .version-selector {
+    top: 1em;
+  }
+}
 
 
 /* Section: Typography
@@ -494,8 +519,4 @@ code, pre {
 
 .decl-inner {
     padding: 0 0.9em;
-}
-
-.documentation-contents li {
-    font-size: 1.3em;
 }

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -252,19 +252,19 @@ img {
 }
 
 /* Version selector */
-select.version-selector {
+.version-selector {
   float: left;
   width: auto;
   min-width: 20%;
 }
 
 /* GitHub rendered README */
-article.entry-content p:first-child {
+.entry-content p:first-child {
   margin-top: 0;
 }
 
 /* Search results */
-a.search-result {
+.search-result {
   display: block;
   background: #{Css.codeBackground};
   padding: 0.2em 1em;
@@ -275,20 +275,20 @@ a.search-result {
   border-radius: 5px;
 }
 
-a.search-result .highlight {
+.search-result .highlight {
   color: #{Css.linkColor};
 }
 
-a.search-result p:first-child {
+.search-result p:first-child {
   margin-bottom: 0.5em;
 }
 
-a.search-result p:nth-child(2) {
+.search-result p:nth-child(2) {
   margin-top: 0.5em;
 }
 
-a.search-result:hover,
-a.search-result:focus {
+.search-result:hover,
+.search-result:focus {
   text-decoration: none;
   background: #{Css.lighten5 Css.codeBackground};
   border: 1px solid #{Css.codeForeground};
@@ -383,7 +383,7 @@ code, pre {
     padding: 0 0.9em;
 }
 
-ul.documentation-contents li {
+.documentation-contents li {
     font-size: 1.3em;
 }
 

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -151,6 +151,68 @@ a:hover {
   text-decoration: none;
 }
 
+code, pre {
+  background-color: #{Css.codeBackground};
+  border-radius: 3px;
+  color: #{Css.codeForeground};
+  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-size: 87.5%;
+}
+
+code {
+  padding: 0.2em 0;
+  margin: 0;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+code::before,
+code::after {
+  letter-spacing: -0.2em;
+  content: "\00a0";
+}
+
+a > code {
+  font-weight: normal;
+}
+
+a > code::before {
+  content: "🡒";
+  letter-spacing: 0.33em;
+}
+
+a:hover > code {
+  color: #{Css.linkColor};
+}
+
+pre {
+  margin-top: 0;
+  margin-bottom: 0;
+  padding: 1em 1.25rem; /* Using rem here to align with lists etc. */
+  overflow: auto;
+  white-space: pre;
+  word-wrap: normal;
+}
+
+pre code {
+  background-color: transparent;
+  border: 0;
+  font-size: 100%;
+  max-width: auto;
+  padding: 0;
+  margin: 0;
+  overflow: visible;
+  line-height: inherit;
+  white-space: pre;
+  word-break: normal;
+  word-wrap: normal;
+}
+
+pre code::before,
+pre code::after {
+  content: normal;
+}
+
 h1 {
   font-size: 3.814em;
   font-weight: 300;
@@ -174,22 +236,18 @@ hr {
 }
 
 img {
+  border-style: none;
   max-width: 100%;
 }
 
 p {
   font-size: 1em;
-
-  /*
-  Useful for narrow screens, such as mobiles. Documentation often contains URLs
-  which would otherwise force the page to become wider, and force creation of
-  horizontal scrollbars. Yuck.
-  */
-  word-wrap: break-word;
 }
 
 table {
   border-bottom: 1px solid #{Css.darken20 Css.backgroundColor};
+  border-collapse: collapse;
+  border-spacing: 0;
   width: 100%;
 }
 
@@ -461,25 +519,9 @@ ol li {
 }
 
 
-/* Section: Typography
- * Font sizes are based on a major third scale (1:1.250)
+/* Section: FIXME
+ * These styles should be cleaned up
  * ========================================================================== */
-
-}
-
-}
-
-
-
-h2.re-exports {
-  padding-top: 0.5em;
-}
-
-
-/* GitHub rendered README */
-.entry-content p:first-child {
-  margin-top: 0;
-}
 
 /* Help paragraphs */
 .help {
@@ -490,13 +532,10 @@ h2.re-exports {
   margin-top: 16px;
 }
 
-/* Code */
-code, pre {
-  color: #{Css.codeForeground};
-  background-color: #{Css.codeBackground};
-  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
-  white-space: pre-wrap;
-  word-wrap: break-word;
+
+
+h2.re-exports {
+  padding-top: 0.5em;
 }
 
 .code-block {
@@ -504,30 +543,6 @@ code, pre {
   padding: 0.5em 1em;
 }
 
-/* Code highlighting */
-.keyword, .syntax, .pl-k {
-  color: #a0a0a0;
-}
-
-.pl-c1, .pl-en {
-  /* Not really sure what this is */
-  color: #39d;
-}
-
-.pl-s {
-  /* String literals */
-  color: #1a1;
-}
-
-.pl-cce {
-  /* String literal escape sequences */
-  color: #921;
-}
-
-.pl-smi {
-  /* type variables? */
-  color: #62b;
-}
 
 /* Everything else */
 .decl {
@@ -540,4 +555,82 @@ code, pre {
 
 .decl-inner {
     padding: 0 0.9em;
+}
+
+/* Code highlighting */
+.keyword, .syntax {
+  color: #a0a0a0;
+}
+
+
+/* Section: Markdown
+ * Github rendered README
+ * ========================================================================== */
+
+.markdown-body {
+  /*
+  Useful for narrow screens, such as mobiles. Documentation often contains URLs
+  which would otherwise force the page to become wider, and force creation of
+  horizontal scrollbars. Yuck.
+  */
+  word-wrap: break-word;
+}
+
+.markdown-body>*:first-child {
+  margin-top: 0 !important;
+}
+
+.markdown-body>*:last-child {
+  margin-bottom: 0 !important;
+}
+
+.markdown-body a:not([href]) {
+  color: inherit;
+  text-decoration: none;
+}
+
+.markdown-body blockquote {
+  margin: 0;
+  padding: 0 1em;
+  color: #777;
+  border-left: 0.25em solid #ddd;
+}
+
+.markdown-body blockquote>:first-child {
+  margin-top: 0;
+}
+
+.markdown-body blockquote>:last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body .anchor {
+  /* We hide the anchor because the link doesn't point to a valid location */
+  display: none;
+}
+
+.markdown-body .pl-k {
+  /* Keyword */
+  color: #a0a0a0;
+}
+
+.markdown-body .pl-c1,
+.markdown-body .pl-en {
+  /* Not really sure what this is */
+  color: #39d;
+}
+
+.markdown-body .pl-s {
+  /* String literals */
+  color: #1a1;
+}
+
+.markdown-body .pl-cce {
+  /* String literal escape sequences */
+  color: #921;
+}
+
+.markdown-body .pl-smi {
+  /* type variables? */
+  color: #62b;
 }

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -13,7 +13,14 @@ body {
   background-color: #{Css.backgroundColor};
   color: #000;
   font-family: "Roboto", sans-serif;
+  font-size: 87.5%;
   line-height: 1.563em;
+}
+
+@media (min-width: 38em) {
+  body {
+    font-size: 100%;
+  }
 }
 
 
@@ -45,49 +52,41 @@ body {
  * ========================================================================== */
 
 .container {
-  max-width: 1060px;
+  display: block;
+  max-width: 66em;
   margin-left: auto;
   margin-right: auto;
-  padding: 7px;
+  padding-left: 20px;
+  padding-right: 20px;
 }
 
-.col h1,
-.col h2,
-.col h3,
-.col h4,
-.col h5,
-.col h6,
-.col p,
-.col ul,
-.col ol,
-.col pre,
-.col .version-selector.container,
-.col form,
-.col table,
 .col {
-  padding: 0 10px;
+  display: block;
+  width: 100%;
 }
 
-@media (min-width: 50em) {
-  .col {
-    width: 70%
+@media (min-width: 52em) {
+  .container {
+    padding-left: 30px;
+    padding-right: 30px;
   }
 
-  .col-single {
-    width: 100%;
-    margin-right: auto;
-    margin-left: auto;
-  }
-}
-
-@media (min-width: 70em) {
-  .col.col-main {
+  .col.col--main {
     float: left;
+    width: 67%
   }
 
-  .col.col-aside {
-    width: 30%;
+  .col.col--aside {
     float: right;
+    font-size: 87.5%;
+    padding-left: 30px;
+    width: 33%;
+  }
+}
+
+@media (min-width: 66em) {
+  .col.col--aside {
+    font-size: inherit;
   }
 }
 
@@ -288,7 +287,7 @@ p {
   font-size: 150%;
 }
 
-@media (min-width: 50em) {
+@media (min-width: 52em) {
   .top-banner .banner-item {
     float: left;
   }
@@ -368,6 +367,7 @@ a h2 { /* FIXME: target with class name instead */
 
 ul {
   list-style-type: none;
+  padding-left: 0;
 }
 
 ul li {
@@ -385,7 +385,7 @@ ul li:before {
 }
 
 ol {
-
+  padding-left: 0;
 }
 
 ol li {
@@ -398,9 +398,7 @@ h2.re-exports {
 
 
 /* Tables */
-table { /* FIXME: possibly wrap table in div */
-  /* Seemingly necessary for the ".col table" rule above to work */
-  display: block;
+table {
 }
 
 td, th {

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -287,64 +287,70 @@ p {
 .top-banner {
   background-color: #{Css.bannerBackground};
   color: #{Css.darkForeground};
-  font-weight: lighter;
-  line-height: 3.5em;
-  padding: 5px 0;
-  text-decoration: none;
-  vertical-align: middle;
+  font-weight: normal;
 }
 
-.top-banner a,
-.top-banner a:visited {
-  background-color: #{Css.bannerBackground};
+.top-banner__logo,
+.top-banner__logo:visited {
+  float: left;
   color: #{Css.darkForeground};
+  font-size: 2.44em;
+  font-weight: 300;
+  line-height: 90px;
+  margin: 0;
+}
+
+.top-banner__logo:hover {
+  color: #DCAB4E; /* FIXME: define color from color scheme */
   text-decoration: none;
-  font-weight: lighter;
-  padding: 5px 0;
 }
 
-.top-banner a:hover {
-  background-color: #{Css.lighten10 Css.bannerBackground};
+.top-banner__form {
+  margin-bottom: 1.25em;
 }
 
-.top-banner .pursuit {
-  font-size: 150%;
-}
-
-.top-banner form {
-  color: #{Css.bannerBackground};
-}
-
-.top-banner input {
-  width: 100%;
-  line-height: 1.5em;
-  padding: 0.2em;
+.top-banner__form input {
+  border: 1px solid #{Css.bannerBackground};
   border-radius: 3px;
+  color: #{Css.bannerBackground};
+  font-weight: 300;
+  line-height: 2;
+  padding: 0.21em 0.512em;
+  width: 100%;
 }
 
-.top-banner .banner-item {
-  padding: 0 17px;
+.top-banner__actions {
+  float: right;
+  text-align: right;
 }
 
-.top-banner .banner-item.upload {
-  font-size: 150%;
+.top-banner__actions__item {
+  display: inline-block;
+  line-height: 90px;
+  margin: 0;
+  padding-left: 1.25em;
 }
 
-@media (min-width: 52em) {
-  .top-banner .banner-item {
+.top-banner__actions__item:first-child {
+  padding-left: 0;
+}
+
+@media (min-width: 38em) {
+  .top-banner__logo {
     float: left;
+    width: 25%;
   }
 
-  .top-banner .banner-item.pursuit {
-    margin-right: 3em;
-  }
-
-  .top-banner form.banner-item {
+  .top-banner__form {
+    float: left;
+    line-height: 90px;
+    margin-bottom: 0;
     width: 50%;
   }
 
-  .top-banner .banner-item.upload {
+  .top-banner__actions {
     float: right;
+    width: 25%;
   }
 }
 

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -137,10 +137,6 @@ html, body {
 
 :target {
   background-color: #{Css.codeBackground};
-  margin-left: -100%;
-  margin-right: -100%;
-  padding-left: 100%;
-  padding-right: 100%;
 }
 
 a, a:visited {

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -747,14 +747,15 @@ ol li {
  * -------------------------------------------------------------------------- */
 
 .version-selector {
-  position: absolute;
-  top: 0.512em;
-  right: 0;
+  margin-bottom: 0.8em;
 }
 
 @media (min-width: 38em) {
   .version-selector {
-    top: 1em;
+    position: absolute;
+    top: 0.8em;
+    right: 0;
+    margin-bottom: 0;
   }
 }
 

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -135,6 +135,14 @@ html, body {
  * influence every component hereafter.
  * ========================================================================== */
 
+:target {
+  background-color: #{Css.codeBackground};
+  margin-left: -100%;
+  margin-right: -100%;
+  padding-left: 100%;
+  padding-right: 100%;
+}
+
 a, a:visited {
   color: #{Css.linkColor};
   text-decoration: none;
@@ -152,6 +160,11 @@ code, pre {
   color: #{Css.codeForeground};
   font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
   font-size: 87.5%;
+}
+
+:target code,
+:target pre {
+  background-color: #{Css.darken5 Css.codeBackground};
 }
 
 code {
@@ -552,14 +565,6 @@ ol li {
 
 .decl {}
 
-.decl:target {
-  background-color: #{Css.codeBackground};
-  margin-left: -100%;
-  margin-right: -100%;
-  padding-left: 100%;
-  padding-right: 100%;
-}
-
 .decl__title {
   position: relative;
   padding-bottom: 0.328em;
@@ -597,6 +602,12 @@ ol li {
   padding-left: 2.441em;
   text-indent: -2.441em;
   white-space: normal;
+}
+
+:target .decl__signature,
+:target .decl__signature code {
+  /* We want the background to be transparent, even when the parent is a target */
+  background-color: transparent;
 }
 
 .decl__body .keyword,

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -5,7 +5,7 @@ html {
   box-sizing: border-box;
 }
 
-*, *:before, *:after {
+*, *::before, *::after {
   box-sizing: inherit;
 }
 
@@ -27,13 +27,13 @@ body {
 /* Section: Utility Classes
  * ========================================================================== */
 
-.clearfix:before,
-.clearfix:after {
+.clearfix::before,
+.clearfix::after {
   content: " ";
   display: table;
 }
 
-.clearfix:after {
+.clearfix::after {
   clear: both;
 }
 
@@ -220,7 +220,7 @@ ul li {
   padding-left: 1.250em;
 }
 
-ul li:before {
+ul li::before {
   position: absolute;
   color: #{Css.lightGlyphColor};
   content: "–";

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -9,8 +9,9 @@ html {
 }
 
 body {
-  font-family: "Roboto", sans-serif;
   background-color: #{Css.backgroundColor};
+  font-family: "Roboto", sans-serif;
+  line-height: 1.563em;
 }
 
 /* Utility classes */
@@ -56,11 +57,6 @@ body {
 .col table,
 .col {
   padding: 0 10px;
-}
-
-.col ul,
-.col ol {
-  padding-left: 45px;
 }
 
 .top-banner .banner-item {
@@ -175,26 +171,65 @@ html, body {
   border-color: #{Css.darken20 Css.notAvailableBackgroundColor};
 }
 
-/* Typography */
-h1, h2 {
+/**
+ * Typography
+ * Font sizes are based on a major third scale (1:1.250)
+ * -------------------------------------------------------------------------- */
+
+h1 {
+  font-size: 3.814em;
+  font-weight: normal;
+  letter-spacing: -0.5px;
+  line-height: 1.125;
+}
+
+h2 {
+  font-size: 1.953em;
   font-weight: normal;
 }
 
 h3 {
-  font-size: 1.4em;
+  font-size: 1.563em;
 }
 
-a h2 {
+a h2 { /* FIXME: target with class name instead */
   margin-top: 0.83em;
 }
 
-/*
+p {
+  font-size: 1em;
+
+  /*
   Useful for narrow screens, such as mobiles. Documentation often contains URLs
   which would otherwise force the page to become wider, and force creation of
   horizontal scrollbars. Yuck.
-*/
-p {
+  */
   word-wrap: break-word;
+}
+
+ul {
+  list-style-type: none;
+}
+
+ul li {
+  position: relative;
+  padding-left: 1.250em;
+}
+
+ul li:before {
+  position: absolute;
+  color: #{Css.lightGlyphColor};
+  content: "–";
+  display: inline-block;
+  margin-left: -1.250em;
+  width: 1.250em;
+}
+
+ol {
+
+}
+
+ol li {
 }
 
 /* Tables */
@@ -258,6 +293,19 @@ a.search-result:focus {
   background: #{Css.lighten5 Css.codeBackground};
   border: 1px solid #{Css.codeForeground};
   outline: none;
+}
+
+/* Dependencies */
+.dependency-link {
+  display: inline-block;
+  margin-right: 0.41em;
+}
+
+.dependency-version {
+  color: #{Css.lightTypeColor};
+  display: inline-block;
+  font-size: 0.8em;
+  line-height: 1;
 }
 
 /* Help paragraphs */

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -165,16 +165,14 @@ img {
 /* Component: Dependency Link
  * -------------------------------------------------------------------------- */
 
-.dependency-link {
+.deplink { /* Currently no root styles, but keep the class as a namespace */ }
+
+.deplink__link {
   display: inline-block;
   margin-right: 0.41em;
 }
 
-
-/* Component: Dependency Version
- * -------------------------------------------------------------------------- */
-
-.dependency-version {
+.deplink__version {
   color: #{Css.lightTypeColor};
   display: inline-block;
   font-size: 0.8em;

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -31,6 +31,11 @@
 
 html {
   box-sizing: border-box;
+
+  /* This overflow rule prevents everything from shifting slightly to the side
+     when moving from a page which isn't large enough to generate a scrollbar
+     to one that is. */
+  overflow-y: scroll;
 }
 
 *, *::before, *::after {

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -188,6 +188,56 @@ p {
   word-wrap: break-word;
 }
 
+table {
+  border-bottom: 1px solid #{Css.darken20 Css.backgroundColor};
+  width: 100%;
+}
+
+td, th {
+  text-align: left;
+  padding: 0.41em 0.51em;
+}
+
+td {
+  border-top: 1px solid #{Css.darken20 Css.backgroundColor};
+}
+
+td:first-child, th:first-child {
+  padding-left: 0;
+}
+
+td:last-child, th:last-child {
+  padding-right: 0;
+}
+
+ul {
+  list-style-type: none;
+  padding-left: 0;
+}
+
+ul li {
+  position: relative;
+  padding-left: 1.250em;
+}
+
+ul li:before {
+  position: absolute;
+  color: #{Css.lightGlyphColor};
+  content: "–";
+  display: inline-block;
+  margin-left: -1.250em;
+  width: 1.250em;
+}
+
+ol {
+  padding-left: 1.250em;
+}
+
+ol li {
+  position: relative;
+  padding-left: 0;
+}
+
 
 /* Section: Components
  * ========================================================================== */
@@ -415,49 +465,14 @@ p {
  * Font sizes are based on a major third scale (1:1.250)
  * ========================================================================== */
 
-
-ul {
-  list-style-type: none;
-  padding-left: 0;
 }
 
-ul li {
-  position: relative;
-  padding-left: 1.250em;
 }
 
-ul li:before {
-  position: absolute;
-  color: #{Css.lightGlyphColor};
-  content: "–";
-  display: inline-block;
-  margin-left: -1.250em;
-  width: 1.250em;
-}
-
-ol {
-  padding-left: 0;
-}
-
-ol li {
-}
 
 
 h2.re-exports {
   padding-top: 0.5em;
-}
-
-
-/* Tables */
-table {
-}
-
-td, th {
-  padding: 0.4em;
-}
-
-tbody tr:nth-child(odd) {
-  background-color: #eee;
 }
 
 

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -225,6 +225,36 @@ p {
 }
 
 
+/* Component: Page Title
+ * -------------------------------------------------------------------------- */
+
+.page-title {
+  border-bottom: 1px solid #{Css.darken20 Css.backgroundColor};
+  margin: 2.44em 0 3.05em;
+  padding-bottom: 1.25em;
+  position: relative;
+}
+
+.page-title__title {
+  float: left;
+  margin: 0;
+}
+
+.page-title__version-selector {
+  position: absolute;
+  top: -1em;
+  right: 0;
+}
+
+@media (min-width: 52em) {
+  .page-title__version-selector {
+    position: static;
+    float: right;
+    margin-top: 2.6em;
+  }
+}
+
+
 /* Component: Package Label
  * -------------------------------------------------------------------------- */
 
@@ -344,17 +374,7 @@ p {
 /* Component: Version Selector
  * -------------------------------------------------------------------------- */
 
-.version-selector {
-  float: left;
-  width: auto;
-  min-width: 20%;
-}
-
-@media (min-width: 70em) {
-  .version-selector {
-    margin-top: 1em;
-  }
-}
+.version-selector { /* No styles at the moment */ }
 
 
 /* Section: Typography

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -266,20 +266,18 @@ p {
 }
 
 .page-title__title {
-  margin: 0;
+  margin: 0 0 0 -0.05em; /* Visually align on left edge */
 }
 
-
-/* Component: Package Label
- * -------------------------------------------------------------------------- */
-
-.package-label {
+.page-title__label {
+  position: relative;
   color: #{Css.lightTypeColor};
-  display: block;
   font-size: 0.8rem;
+  font-weight: 300;
   letter-spacing: 1px;
-  margin-bottom: -0.41em;
+  margin-bottom: -0.8em;
   text-transform: uppercase;
+  z-index: 1;
 }
 
 

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -191,17 +191,12 @@ img {
   padding: 1em !important;
 }
 
-.error {
+.message.message--error {
   background-color: #{Css.errorBackgroundColor};
   border-color: #{Css.errorBorderColor};
 }
 
-.success {
-  background-color: #{Css.successBackgroundColor};
-  border-color: #{Css.darken20 Css.successBackgroundColor};
-}
-
-.not-available {
+.message.message--not-available {
   background-color: #{Css.notAvailableBackgroundColor};
   border-color: #{Css.darken20 Css.notAvailableBackgroundColor};
 }

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -25,7 +25,8 @@ body {
   clear: both;
 }
 
-.sr-only {
+/* Content hidden like will be read by a screen reader */
+.hide-visually {
   position: absolute;
   left: -10000px;
   top: auto;
@@ -233,7 +234,7 @@ ol li {
 }
 
 /* Tables */
-table {
+table { /* FIXME: possibly wrap table in div */
   /* Seemingly necessary for the ".col table" rule above to work */
   display: block;
 }
@@ -323,7 +324,7 @@ img {
   padding: 5px 0;
 }
 
-.help h3 {
+.help h3 { /* FIXME: target with class */
   margin-top: 16px;
 }
 
@@ -331,6 +332,7 @@ img {
 code, pre {
   color: #{Css.codeForeground};
   background-color: #{Css.codeBackground};
+  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
   white-space: pre-wrap;
   word-wrap: break-word;
 }

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -1,6 +1,8 @@
 /** ************************************************************************* *
  ** Pursuit CSS
  **
+ ** STRUCTURE
+ **
  ** This CSS file is structured into several sections, from general to
  ** specific, and (mostly) alphabetically within the sections.
  **
@@ -23,6 +25,16 @@
  **     <div .my-component__item>
  **
  ** Components can be nested.
+ **
+ **
+ ** TYPOGRAPHY
+ **
+ ** Typographic choices for sizes, line-heights and margins are based on a
+ ** musical major third scale (4:5). This gives us a way to find numbers
+ ** and relationships between them that are perceived as harmonic.
+ **
+ ** To make use of this modular scale, follow this formula:
+ **   (5/4)^n | n ∈ [-6, 8]
  ** ************************************************************************* */
 
 

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -178,7 +178,7 @@ html, body {
 
 h1 {
   font-size: 3.814em;
-  font-weight: normal;
+  font-weight: 300;
   letter-spacing: -0.5px;
   line-height: 1.125;
 }
@@ -306,6 +306,16 @@ a.search-result:focus {
   display: inline-block;
   font-size: 0.8em;
   line-height: 1;
+}
+
+/* Package label */
+.package-label {
+  color: #{Css.lightTypeColor};
+  display: block;
+  font-size: 0.8rem;
+  letter-spacing: 1px;
+  margin-bottom: -0.41em;
+  text-transform: uppercase;
 }
 
 /* Help paragraphs */

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -135,11 +135,6 @@ html, body {
  * influence every component hereafter.
  * ========================================================================== */
 
-:target {
-  background-color: #{Css.codeBackground};
-  border-radius: 5px;
-}
-
 a, a:visited {
   color: #{Css.linkColor};
   text-decoration: none;
@@ -227,6 +222,12 @@ h2 {
 
 h3 {
   font-size: 1.563em;
+  font-weight: normal;
+}
+
+h4 {
+  font-size: 1.25em;
+  font-weight: normal;
 }
 
 hr {
@@ -519,6 +520,63 @@ ol li {
 }
 
 
+/* Component: Declarations
+ * -------------------------------------------------------------------------- */
+
+.decl {}
+
+.decl:target {
+  background-color: #{Css.codeBackground};
+  margin-left: -100%;
+  margin-right: -100%;
+  padding-left: 100%;
+  padding-right: 100%;
+}
+
+.decl__title {
+  position: relative;
+  padding-bottom: 0.328em;
+  margin: 2.44em 0 0.262em 0;
+}
+
+.decl__source {
+  display: block;
+  float: right;
+  font-size: 1rem;
+  line-height: 2;
+}
+
+.decl__anchor, .decl__anchor:visited {
+  position: absolute;
+  left: -0.8em;
+  color: #{Css.lighten10 Css.lightGlyphColor};
+}
+
+.decl__anchor:hover {
+  color: #{Css.linkColor};
+}
+
+.decl__signature {
+  background-color: transparent;
+  border-radius: 0;
+  border-top: 1px solid #{Css.darken20 Css.backgroundColor};
+  border-bottom: 1px solid #{Css.darken20 Css.backgroundColor};
+  padding: 0.328em 0 0 0;
+}
+
+.decl__signature code {
+  display: block;
+  padding-left: 2.441em;
+  text-indent: -2.441em;
+  white-space: normal;
+}
+
+.decl__body .keyword,
+.decl__body .syntax {
+  color: #a0a0a0;
+}
+
+
 /* Section: FIXME
  * These styles should be cleaned up
  * ========================================================================== */
@@ -530,36 +588,6 @@ ol li {
 
 .help h3 { /* FIXME: target with class */
   margin-top: 16px;
-}
-
-
-
-h2.re-exports {
-  padding-top: 0.5em;
-}
-
-.code-block {
-  display: block;
-  padding: 0.5em 1em;
-}
-
-
-/* Everything else */
-.decl {
-    margin-top: 2em;
-}
-
-.decl h3 {
-    padding-top: 0.4em;
-}
-
-.decl-inner {
-    padding: 0 0.9em;
-}
-
-/* Code highlighting */
-.keyword, .syntax {
-  color: #a0a0a0;
 }
 
 

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -337,6 +337,90 @@ ol li {
 /* Section: Components
  * ========================================================================== */
 
+/* Component: Badge
+ * -------------------------------------------------------------------------- */
+
+.badge {
+  position: relative;
+  top: -0.1em;
+  display: inline-block;
+  background-color: #000;
+  border-radius: 1.3em;
+  color: #fff;
+  font-size: 77%;
+  font-weight: bold;
+  line-height: 1.563;
+  text-align: center;
+  height: 1.5em;
+  width: 1.5em;
+}
+
+.badge.badge--package {
+  background-color: #{Css.linkColor};
+  letter-spacing: -0.1em;
+}
+
+.badge.badge--module {
+  background-color: #75B134;
+}
+
+
+/* Component: Declarations
+ * -------------------------------------------------------------------------- */
+
+.decl {}
+
+.decl__title {
+  position: relative;
+  padding-bottom: 0.328em;
+  margin-bottom: 0.262em;
+}
+
+.decl__source {
+  display: block;
+  float: right;
+  font-size: 64%;
+  position: relative;
+  top: 0.57em;
+}
+
+.decl__anchor, .decl__anchor:visited {
+  position: absolute;
+  left: -0.8em;
+  color: #{Css.lighten10 Css.lightGlyphColor};
+}
+
+.decl__anchor:hover {
+  color: #{Css.linkColor};
+}
+
+.decl__signature {
+  background-color: transparent;
+  border-radius: 0;
+  border-top: 1px solid #{Css.darken20 Css.backgroundColor};
+  border-bottom: 1px solid #{Css.darken20 Css.backgroundColor};
+  padding: 0.328em 0 0 0;
+}
+
+.decl__signature code {
+  display: block;
+  padding-left: 2.441em;
+  text-indent: -2.441em;
+  white-space: normal;
+}
+
+:target .decl__signature,
+:target .decl__signature code {
+  /* We want the background to be transparent, even when the parent is a target */
+  background-color: transparent;
+}
+
+.decl__body .keyword,
+.decl__body .syntax {
+  color: #a0a0a0;
+}
+
+
 /* Component: Dependency Link
  * -------------------------------------------------------------------------- */
 
@@ -508,35 +592,54 @@ ol li {
 /* Component: Search Results
  * -------------------------------------------------------------------------- */
 
-.search-result {
+.result {}
+
+.result.result--empty {
+  font-size: 1.25em;
+}
+
+.result__title {
+  font-size: 1.25em;
+  margin-bottom: 0.2rem;
+}
+
+.result__badge {
+  margin-left: -0.1em;
+}
+
+.result__body > *:first-child {
+  margin-top: 0!important;
+}
+
+.result__body > *:last-child {
+  margin-bottom: 0!important;
+}
+
+.result__signature {
+  background-color: transparent;
+  border-radius: 0;
+  border-top: 1px solid #{Css.darken20 Css.backgroundColor};
+  border-bottom: 1px solid #{Css.darken20 Css.backgroundColor};
+  padding: 0.328em 0 0 0;
+}
+
+.result__signature code {
   display: block;
-  background: #{Css.codeBackground};
-  padding: 0.2em 1em;
-  margin-bottom: 1em;
-  color: #000;
-  font-weight: normal;
-  border: 1px solid #{Css.codeBackground};
-  border-radius: 5px;
+  padding-left: 2.441em;
+  text-indent: -2.441em;
+  white-space: normal;
 }
 
-.search-result .highlight {
-  color: #{Css.linkColor};
+.result__actions {
+  margin-top: 0.2rem;
 }
 
-.search-result p:first-child {
-  margin-bottom: 0.5em;
+.result__actions__item {
+  font-size: 80%;
 }
 
-.search-result p:nth-child(2) {
-  margin-top: 0.5em;
-}
-
-.search-result:hover,
-.search-result:focus {
-  text-decoration: none;
-  background: #{Css.lighten5 Css.codeBackground};
-  border: 1px solid #{Css.codeForeground};
-  outline: none;
+.result__actions__item + .result__actions__item {
+  margin-left: 0.65em;
 }
 
 
@@ -553,62 +656,6 @@ ol li {
   .version-selector {
     top: 1em;
   }
-}
-
-
-/* Component: Declarations
- * -------------------------------------------------------------------------- */
-
-.decl {}
-
-.decl__title {
-  position: relative;
-  padding-bottom: 0.328em;
-  margin-bottom: 0.262em;
-}
-
-.decl__source {
-  display: block;
-  float: right;
-  font-size: 64%;
-  position: relative;
-  top: 0.57em;
-}
-
-.decl__anchor, .decl__anchor:visited {
-  position: absolute;
-  left: -0.8em;
-  color: #{Css.lighten10 Css.lightGlyphColor};
-}
-
-.decl__anchor:hover {
-  color: #{Css.linkColor};
-}
-
-.decl__signature {
-  background-color: transparent;
-  border-radius: 0;
-  border-top: 1px solid #{Css.darken20 Css.backgroundColor};
-  border-bottom: 1px solid #{Css.darken20 Css.backgroundColor};
-  padding: 0.328em 0 0 0;
-}
-
-.decl__signature code {
-  display: block;
-  padding-left: 2.441em;
-  text-indent: -2.441em;
-  white-space: normal;
-}
-
-:target .decl__signature,
-:target .decl__signature code {
-  /* We want the background to be transparent, even when the parent is a target */
-  background-color: transparent;
-}
-
-.decl__body .keyword,
-.decl__body .syntax {
-  color: #a0a0a0;
 }
 
 

--- a/templates/help.hamlet
+++ b/templates/help.hamlet
@@ -1,4 +1,4 @@
-<div .col.col-main>
+<div .col.col--main>
   <div .help>
     <h2>Help!
     <p>

--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -1,7 +1,9 @@
-<div .col.col--main>
+<div .col>
   <h1>
     <strong>Pursuit
     is the home of PureScript documentation.
+
+<div .col.col--main>
   <p>
     Pursuit hosts generated API documentation for PureScript packages.
   <p>

--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -1,5 +1,5 @@
 <div .col .col-main>
-  <h2>
+  <h1>
     <strong>Pursuit
     is the home of PureScript documentation.
   <p>

--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -29,13 +29,13 @@
       Contributions are welcome: <a href="https://github.com/purescript/pursuit">https://github.com/purescript/pursuit</a>.
 
 <div .clear-floats>
+  <h2>Package Index
   $if null pkgNames
-    <h2>Package index
     <p>No packages uploaded yet.
   $else
-    <div .multi-col .clearfix>
+    <div .multi-col .clearfix style="margin-top: -2.441em">
       <div .multi-col__col>
-        <h3>Latest packages
+        <h3>Latest uploads
         <ul>
           $forall (pkgName, version) <- latest
             <li>

--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -1,33 +1,53 @@
 <div .col>
   <h1>
     <strong>Pursuit
-    is the home of PureScript documentation.
+    is the home of PureScript documentation
 
 <div .col.col--main>
   <p>
-    Pursuit hosts generated API documentation for PureScript packages.
-  <p>
-    If you are a package author looking for information on how to publish your
-    packages, see the <a href=@{HelpR}>Help page</a>.
-  <p>
-    Pursuit is free and open-source software, and the code is hosted on GitHub.
-    Contributions are welcome: <a href="https://github.com/purescript/pursuit">https://github.com/purescript/pursuit</a>.
+    Pursuit hosts API documentation for <a href="http://www.purescript.org/">PureScript</a> packages. It lets you search by package, module, and function names, as well as approximate type signatures.
 
+  <p>
+    To get started, have a look around the <a href="/packages/purescript-prelude">Prelude</a> – PureScript’s standard library – or try one of these example searches:
+
+  <ul .ul--search>
+    <li><a href="/search?q=map">map</a></li>
+    <li><a href="/search?q=%28a+->+b%29+->+f+a+->+f+b">(a -> b) -> f a -> f b</a></li>
+    <li><a href="/search?q=Data.List">Data.List</a></li>
+
+<div .col.col--aside>
+  <dl .grouped-list style="margin-top: 0.6em">
+    <dt .grouped-list__title>Publish
+    <dd .grouped-list__item>
+      If you are a package author looking for information on how to publish your
+      packages, see the <a href=@{HelpR}>Help page</a>.
+
+  <dl .grouped-list>
+    <dt .grouped-list__title>Contribute
+    <dd .grouped-list__item>
+      Pursuit is free and open-source software, and the code is hosted on GitHub.
+      Contributions are welcome: <a href="https://github.com/purescript/pursuit">https://github.com/purescript/pursuit</a>.
+
+<div .clear-floats>
   $if null pkgNames
-    <h2>No packages uploaded yet.
+    <h2>Package index
+    <p>No packages uploaded yet.
   $else
-    <h2>Latest Uploads
-    <ul>
-      $forall (pkgName, version) <- latest
-        <li>
-          <div .deplink>
-            <a .deplink__link href=@{PackageVersionR (PathPackageName pkgName) (PathVersion version)}>#{runPackageName pkgName}
-            <span .deplink__version>#{showVersion version}
-    <h2>Packages:
-      $forall pkgs <- pkgNamesByLetter
-        $forall letter <- headMay pkgs >>= firstLetter
-          <h3>#{letter}
+    <div .multi-col .clearfix>
+      <div .multi-col__col>
+        <h3>Latest packages
         <ul>
-          $forall pkgName <- pkgs
+          $forall (pkgName, version) <- latest
             <li>
-              <a href=@{PackageR (PathPackageName pkgName)}>#{runPackageName pkgName}
+              <div .deplink>
+                <a .deplink__link href=@{PackageVersionR (PathPackageName pkgName) (PathVersion version)}>#{runPackageName pkgName}
+                <span .deplink__version>#{showVersion version}
+
+      $forall pkgs <- pkgNamesByLetter
+        <div .multi-col__col>
+          $forall letter <- headMay pkgs >>= firstLetter
+            <h3>#{letter}
+          <ul>
+            $forall pkgName <- pkgs
+              <li>
+                <a href=@{PackageR (PathPackageName pkgName)}>#{runPackageName pkgName}

--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -1,4 +1,4 @@
-<div .col .col-main>
+<div .col.col--main>
   <h1>
     <strong>Pursuit
     is the home of PureScript documentation.

--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -20,7 +20,7 @@
     <dt .grouped-list__title>Publish
     <dd .grouped-list__item>
       If you are a package author looking for information on how to publish your
-      packages, see the <a href=@{HelpR}>Help page</a>.
+      packages on Pursuit, see the <a href=@{HelpR}>Help page</a>.
 
   <dl .grouped-list>
     <dt .grouped-list__title>Contribute

--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -18,8 +18,9 @@
     <ul>
       $forall (pkgName, version) <- latest
         <li>
-          <a href=@{PackageVersionR (PathPackageName pkgName) (PathVersion version)}>
-            #{runPackageName pkgName} - #{showVersion version}
+          <div .deplink>
+            <a .deplink__link href=@{PackageVersionR (PathPackageName pkgName) (PathVersion version)}>#{runPackageName pkgName}
+            <span .deplink__version>#{showVersion version}
     <h2>Packages:
       $forall pkgs <- pkgNamesByLetter
         $forall letter <- headMay pkgs >>= firstLetter

--- a/templates/packageVersion.hamlet
+++ b/templates/packageVersion.hamlet
@@ -1,12 +1,12 @@
 <div .clearfix>
-  <div .col.col-main>
+  <div .col.col--main>
     <h1>
       <span .package-label>Package
       #{runPackageName pkgName}
 
   ^{versionSelector pkgName pkgVersion}
 
-<div .col.col-aside>
+<div .col.col--aside>
   <p>#{linkToGithub pkgGithub} on github
   <hr>
   $maybe licenses <- joinLicenses (bowerLicense pkgMeta)
@@ -27,7 +27,7 @@
   <p>uploaded by #{linkToGithubUser pkgUploader}
   <hr>
 
-<div .col.col-main>
+<div .col.col--main>
   #{renderReadme ereadme}
   <hr>
   <h2>

--- a/templates/packageVersion.hamlet
+++ b/templates/packageVersion.hamlet
@@ -2,33 +2,31 @@
   <h1 .page-title__title>
     <span .package-label>Package
     #{runPackageName pkgName}
-  <div .page-title__version-selector>
-    ^{versionSelector pkgName pkgVersion}
-
-<div .col.col--aside>
-  <p>#{linkToGithub pkgGithub} on github
-  <hr>
-  $maybe licenses <- joinLicenses (bowerLicense pkgMeta)
-    <p>#{licenses} licensed
-    <hr>
-  <p>
-    $if null dependencies
-      <strong>No dependencies
-    $else
-      <strong>Dependencies
-      <ul>
-        $forall (depPkg, versionRange) <- dependencies
-          <li>
-            <div .deplink>
-              <a .deplink__link href=@{packageNameRoute depPkg}>#{runPackageName depPkg}
-              <span .deplink__version>#{renderVersionRange versionRange}
-    <hr>
-  <p>uploaded by #{linkToGithubUser pkgUploader}
-  <hr>
 
 <div .col.col--main>
+  ^{versionSelector pkgName pkgVersion}
+
+  <dl .grouped-list>
+    <dt .grouped-list__title>Repository
+    <dd .grouped-list__item>#{linkToGithub pkgGithub}
+    $maybe licenses <- joinLicenses (bowerLicense pkgMeta)
+      <dt .grouped-list__title>License
+      <dd .grouped-list__item>#{licenses}
+    <dt .grouped-list__title>Uploaded by
+    <dd .grouped-list__item>#{linkToGithubUser pkgUploader}
+
   #{renderReadme ereadme}
-  <hr>
-  <h2>
-    <strong>Modules
+
+<div .col.col--aside>
   #{moduleList}
+
+  <dl .grouped-list>
+    <dt .grouped-list__title>Dependencies
+    $if null dependencies
+      <dd .grouped-list__item>No dependencies
+    $else
+      $forall (depPkg, versionRange) <- dependencies
+        <dd .grouped-list__item>
+          <div .deplink>
+            <a .deplink__link href=@{packageNameRoute depPkg}>#{runPackageName depPkg}
+            <span .deplink__version>#{renderVersionRange versionRange}

--- a/templates/packageVersion.hamlet
+++ b/templates/packageVersion.hamlet
@@ -20,8 +20,9 @@
       <ul>
         $forall (depPkg, versionRange) <- dependencies
           <li>
-            <a .dependency-link href=@{packageNameRoute depPkg}>#{runPackageName depPkg}
-            <span .dependency-version>#{renderVersionRange versionRange}
+            <div .deplink>
+              <a .deplink__link href=@{packageNameRoute depPkg}>#{runPackageName depPkg}
+              <span .deplink__version>#{renderVersionRange versionRange}
     <hr>
   <p>uploaded by #{linkToGithubUser pkgUploader}
   <hr>

--- a/templates/packageVersion.hamlet
+++ b/templates/packageVersion.hamlet
@@ -20,8 +20,8 @@
       <ul>
         $forall (depPkg, versionRange) <- dependencies
           <li>
-            <a href=@{packageNameRoute depPkg}>#{runPackageName depPkg}
-            #{renderVersionRange versionRange}
+            <a .dependency-link href=@{packageNameRoute depPkg}>#{runPackageName depPkg}
+            <span .dependency-version>#{renderVersionRange versionRange}
     <hr>
   <p>uploaded by #{linkToGithubUser pkgUploader}
   <hr>

--- a/templates/packageVersion.hamlet
+++ b/templates/packageVersion.hamlet
@@ -1,10 +1,9 @@
-<div .clearfix>
-  <div .col.col--main>
-    <h1>
-      <span .package-label>Package
-      #{runPackageName pkgName}
-
-  ^{versionSelector pkgName pkgVersion}
+<div .page-title .clearfix>
+  <h1 .page-title__title>
+    <span .package-label>Package
+    #{runPackageName pkgName}
+  <div .page-title__version-selector>
+    ^{versionSelector pkgName pkgVersion}
 
 <div .col.col--aside>
   <p>#{linkToGithub pkgGithub} on github

--- a/templates/packageVersion.hamlet
+++ b/templates/packageVersion.hamlet
@@ -1,8 +1,8 @@
 <div .clearfix>
   <div .col.col-main>
     <h1>
-      package
-      <strong>#{runPackageName pkgName}
+      <span .package-label>Package
+      #{runPackageName pkgName}
 
   ^{versionSelector pkgName pkgVersion}
 

--- a/templates/packageVersion.hamlet
+++ b/templates/packageVersion.hamlet
@@ -1,7 +1,6 @@
 <div .page-title .clearfix>
-  <h1 .page-title__title>
-    <span .package-label>Package
-    #{runPackageName pkgName}
+  <div .page-title__label>Package
+  <h1 .page-title__title>#{runPackageName pkgName}
 
 <div .col.col--main>
   ^{versionSelector pkgName pkgVersion}

--- a/templates/packageVersionModuleDocs.hamlet
+++ b/templates/packageVersionModuleDocs.hamlet
@@ -2,4 +2,17 @@
   <div .page-title__label>Module
   <h1 .page-title__title>#{insertBreaks mn}
 
-#{htmlDocs}
+<div .col.col--main>
+  ^{versionSelector pkgName pkgVersion}
+
+  <dl .grouped-list>
+    <dt .grouped-list__title>Package
+    <dd .grouped-list__item><a href=@{packageRoute pkg}>#{runPackageName pkgName}</a>
+    <dt .grouped-list__title>Repository
+    <dd .grouped-list__item>#{linkToGithub pkgGithub}
+
+  #{htmlDocs}
+
+
+<div .col.col--aside>
+  #{moduleList}

--- a/templates/packageVersionModuleDocs.hamlet
+++ b/templates/packageVersionModuleDocs.hamlet
@@ -1,4 +1,5 @@
-<h2>
-  module #
-  <strong>#{insertBreaks mn}
+<h1>
+  <span .package-label>Module
+  #{insertBreaks mn}
+
 #{htmlDocs}

--- a/templates/packageVersionModuleDocs.hamlet
+++ b/templates/packageVersionModuleDocs.hamlet
@@ -1,5 +1,5 @@
-<h1>
-  <span .package-label>Module
-  #{insertBreaks mn}
+<div .page-title .clearfix>
+  <div .page-title__label>Module
+  <h1 .page-title__title>#{insertBreaks mn}
 
 #{htmlDocs}

--- a/templates/search.hamlet
+++ b/templates/search.hamlet
@@ -1,28 +1,46 @@
-<div .col>
-  <h2>Search results: #{query}
+<div .col.col--main>
+  <h1>Search results
+
   $if null results
-    <p>No results for "#{query}", sorry.
+    <div .result.result--empty>
+      Your search for <strong>#{query}</strong> did not yield any results.
   $forall r <- results
-    <a .search-result href=#{fr $ routeResult r}>
+    <div .result>
+      <h3 .result__title>
+        $case hrInfo r
+          $of PackageResult
+            <span .result__badge.badge.badge--package title="Package">P
+            <a .result__link href=#{fr $ routeResult r}>
+              #{Bower.runPackageName $ hrPkgName r}
+          $of ModuleResult moduleName
+            <span .badge.badge--module title="Module">M
+            <a .result__link href=#{fr $ routeResult r}>
+              #{moduleName}
+          $of DeclarationResult _ _ name typ
+            <a .result__link href=#{fr $ routeResult r}>
+              #{name}
+
+    <div .result__body>
       $case hrInfo r
         $of PackageResult
-          <p>#{Bower.runPackageName $ hrPkgName r}
         $of ModuleResult moduleName
-          <p>#{moduleName} (#{Bower.runPackageName $ hrPkgName r})
         $of DeclarationResult _ _ name typ
-          <p>#{name}
-            $maybe typeValue <- typ
-              <span> ::
-              <code>#{typeValue}
+          $maybe typeValue <- typ
+            <pre .result__signature><code>#{name} :: #{typeValue}</code></pre>
 
-      <p>
-        #{renderCommentsNoLinks $ hrComments r}
+      #{renderCommentsNoLinks $ hrComments r}
 
+    <div .result__actions>
       $case hrInfo r
         $of PackageResult
-          <p>
-        $of ModuleResult _
-          <p>
-        $of DeclarationResult _ modName _ _
-          <p>
-            #{modName} (#{Bower.runPackageName $ hrPkgName r})
+        $of ModuleResult moduleName
+          <span .result__actions__item>
+            <span .badge.badge--package title="Package">P
+            #{Bower.runPackageName $ hrPkgName r}
+        $of DeclarationResult _ moduleName _ _
+          <span .result__actions__item>
+            <span .badge.badge--package title="Package">P
+            #{Bower.runPackageName $ hrPkgName r}
+          <span .result__actions__item>
+            <span .badge.badge--module title="Module">M
+            #{moduleName}

--- a/templates/search.hamlet
+++ b/templates/search.hamlet
@@ -1,4 +1,4 @@
-<div .col .col-single>
+<div .col>
   <h2>Search results: #{query}
   $if null results
     <p>No results for "#{query}", sorry.

--- a/templates/search.hamlet
+++ b/templates/search.hamlet
@@ -16,14 +16,14 @@
             <span .badge.badge--module title="Module">M
             <a .result__link href=#{fr $ routeResult r}>
               #{moduleName}
-          $of DeclarationResult _ _ name typ
+          $of DeclarationResult _ _ name _
             <a .result__link href=#{fr $ routeResult r}>
               #{name}
 
     <div .result__body>
       $case hrInfo r
         $of PackageResult
-        $of ModuleResult moduleName
+        $of ModuleResult _
         $of DeclarationResult _ _ name typ
           $maybe typeValue <- typ
             <pre .result__signature><code>#{name} :: #{typeValue}</code></pre>
@@ -33,7 +33,7 @@
     <div .result__actions>
       $case hrInfo r
         $of PackageResult
-        $of ModuleResult moduleName
+        $of ModuleResult _
           <span .result__actions__item>
             <span .badge.badge--package title="Package">P
             #{Bower.runPackageName $ hrPkgName r}

--- a/templates/uploadPackage.hamlet
+++ b/templates/uploadPackage.hamlet
@@ -1,4 +1,4 @@
-<div .col.col-main>
+<div .col.col--main>
   <h2>Upload a package
 
   <div .message .message--not-available>

--- a/templates/uploadPackage.hamlet
+++ b/templates/uploadPackage.hamlet
@@ -1,7 +1,7 @@
 <div .col.col-main>
   <h2>Upload a package
 
-  <div .message .not-available>
+  <div .message .message--not-available>
     <p>
       This upload form is deprecated, and will eventually be removed entirely.
       Please consider switching to Pulp for uploading your packages. There is
@@ -17,7 +17,7 @@
     \.
 
   $maybe err <- merror
-    <div .message .error>
+    <div .message .message--error>
       <p>
         An error occurred, and your package could not be uploaded.
       <p>

--- a/templates/versionSelector.hamlet
+++ b/templates/versionSelector.hamlet
@@ -1,4 +1,4 @@
-<div .col.col-aside>
+<div .col.col--aside>
   <p .version-selector-container>
     <select id=#{versionSelectorIdent} .version-selector>
       <option id="placeholder" disabled="disabled">

--- a/templates/versionSelector.hamlet
+++ b/templates/versionSelector.hamlet
@@ -1,5 +1,3 @@
-<div .col.col--aside>
-  <p .version-selector-container>
-    <select id=#{versionSelectorIdent} .version-selector>
-      <option id="placeholder" disabled="disabled">
-        Loading...
+<select id=#{versionSelectorIdent} .version-selector>
+  <option id="placeholder" disabled="disabled">
+    Loading …


### PR DESCRIPTION
This PR focuses on making Pursuit more useable and beginner friendly by applying a few visual and interaction design recipes. It mainly improves on the following:

* More welcoming homepage with more personality, search examples, and denser presentation of packages.
* Distinctive typographic treatment of the content to provide better visual guidance for the reader.
* Improved display of search results for easier scannability and understandability (e.g. by adding badges to modules and packages to better highlight what they are).
* Clarified navigation between packages and modules and allow navigation from one module to a sibling module.
* Friendlier display of code examples and inline code snippets.

I'll have some more time to work on this this week, so if there are things that I should fix or that I overlooked, please let me know and I'll see that I can add them so this PR could be merged.

_Note: this is a big PR that I should probably have announced before I started working on it. I chose to do this in stealth mode, however, because I was not sure whether I would find the time to properly work on it due to the unpredictability of kids 😬. It did work out and I'm happy to be able to submit this PR._

# Commit summary

## Typography
* Fixed display of italic fonts (no italic font files had been loaded before, making the browser slant the regular font, leading to faux-italics). <img width="388" alt="faux-real-italic" src="https://cloud.githubusercontent.com/assets/10811/21605311/9198e614-d1a8-11e6-9d83-f06d94315fdf.png">
* Lists align with left edge for cleaner look.
* Introduced definition lists for combination of titles and list elements.
* Version numbers are displayed in a smaller font to make them more distinctive.

## CSS

I refactored the CSS quite a bit fully aware that large scale code rewriting is a very bad practice for PRs. However, after working on the previous CSS for a while the many global styles made it very difficult to work with, leading me to believe that it was grown over time and was ready for a refactoring.

I introduced code sections and a naming system based on [BEM](https://en.bem.info/). I understand that this is a controversial naming system; it is very good at creating human-readable namespaces, however, which is needed for creating CSS components that don't influence one another and that can be changed confidently over time. Because it only has three rules (that I applied here) it is easy to apply also for people who don't know what it is.

I tried to keep the CSS small and well structured to make sure other people can make changes to it easily.

* Introduced code sections
* Component naming system based on BEM
* Generalised utility classes
* Extracted existing styles into CSS components
* Improved page layout at various breakpoints
* Treat Github rendered Markdown content separately and clearly namespace it (because we don't control it)

## Other

* Fixed some small accessibility issues

# Discussion

1. [ ] I saw that there is an open issue for a favicon (#109), work on it has been started but stalled. If it's ok, I would make and add a favicon.
2. [ ] Issue #93 mentions contrast of links and other elements. This is something that could be attacked in further design refinements. However, it opens the question on what decisions taken there would mean for the Purescript website. Would that maybe be an undertaking for the Purescript 1.0 release? I like to use living style guides to make sure a design language can grow and is properly applied, but I wouldn't know where to host that (A separate repo? The main Purescript repo?)
3. [ ] A recent PR (https://github.com/purescript/pursuit/commit/27e0ac19026538b04929837c7f9bf5fb1ebe2cb7) introduced a new route to display builtin docs. I have for the time being solved it like so in the new layout: https://github.com/naehrstoff/pursuit/commit/cc9ee90efc8c8fd2c4b36f92cc466f5472f4a6ae Is more needed?
4. [x] After merging in the latest changes I found that some packages did not render or stopped rendering after a while (e.g. purescript-ace). I'm not sure what the cause of this is but suspect that it has to do with the `purescript-backups` packages I use (updated just now) or some caches. If you can reproduce this, please let me know.

# Screenshots

## Homepage

![homepage](https://cloud.githubusercontent.com/assets/10811/21606198/2b036036-d1ae-11e6-8fba-1ee72fe1c648.png)

## Package

![package](https://cloud.githubusercontent.com/assets/10811/21606200/2b04eab4-d1ae-11e6-969f-c39ded87f251.png)

## Module

![module](https://cloud.githubusercontent.com/assets/10811/21606199/2b045374-d1ae-11e6-904a-5ee44caa873d.png)

## Search results

![search-results](https://cloud.githubusercontent.com/assets/10811/21606201/2b062154-d1ae-11e6-86ab-f8a60defad3a.png)

## Code

![code](https://cloud.githubusercontent.com/assets/10811/21606197/2b006692-d1ae-11e6-8397-39806e3a387c.png)