### PR TITLE
Fix inconsistent paddings in code signatures

### DIFF
--- a/templates/default-layout-wrapper.hamlet
+++ b/templates/default-layout-wrapper.hamlet
@@ -6,7 +6,7 @@ $doctype 5
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>#{pageTitle'}
 
-    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,400i,700,700i" type="text/css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Roboto+Mono|Roboto:300,400,400i,700,700i" type="text/css" rel="stylesheet">
     <link href=@{StaticR css_normalize_css} type="text/css" rel="stylesheet">
     <script type="text/javascript" src=@{StaticR js_js_cookie_js}>
     <script type="text/javascript" src=@{StaticR js_Markup_js}>

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -202,7 +202,7 @@ code, pre {
   background-color: #{Css.codeBackground};
   border-radius: 3px;
   color: #{Css.codeForeground};
-  font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
+  font-family: "Roboto Mono", monospace;
   font-size: 87.5%;
 }
 

--- a/templates/default-layout.lucius
+++ b/templates/default-layout.lucius
@@ -461,7 +461,7 @@ ol li {
   border-radius: 0;
   border-top: 1px solid #{Css.darken20 Css.backgroundColor};
   border-bottom: 1px solid #{Css.darken20 Css.backgroundColor};
-  padding: 0.328em 0 0 0;
+  padding: 0.328em 0;
 }
 
 .decl__signature code {
@@ -720,7 +720,7 @@ ol li {
   border-radius: 0;
   border-top: 1px solid #{Css.darken20 Css.backgroundColor};
   border-bottom: 1px solid #{Css.darken20 Css.backgroundColor};
-  padding: 0.328em 0 0 0;
+  padding: 0.328em 0;
 }
 
 .result__signature code {


### PR DESCRIPTION
The original paddings for `result__signature` and `decl__signature` have different top and bottom padding values. This can be seen in the following screenshots.

## Before

#### result__signature

<img width="536" alt="screen shot 2017-01-07 at 03 06 16" src="https://cloud.githubusercontent.com/assets/1013641/21728891/e5fcb114-d48b-11e6-8a2a-8d1b188679b3.png">

#### decl__signature

<img width="550" alt="screen shot 2017-01-07 at 02 49 26" src="https://cloud.githubusercontent.com/assets/1013641/21728903/f2b2fcec-d48b-11e6-8dd2-567ff7f39b9c.png">

## After

After fixing them, they look equal on both top and bottom.

#### result__signature

<img width="658" alt="screen shot 2017-01-07 at 03 42 34" src="https://cloud.githubusercontent.com/assets/1013641/21728930/171834bc-d48c-11e6-9964-41f8e5750c7a.png">

#### decl__signature

<img width="684" alt="screen shot 2017-01-07 at 03 44 10" src="https://cloud.githubusercontent.com/assets/1013641/21728927/10aeffca-d48c-11e6-8298-0d9e45a37ad7.png">