### PR TITLE
Use ghc 8.0.2

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
 resolver: lts-7.14
+compiler: ghc-8.0.2
 flags:
   pursuit:
     dev: true


### PR DESCRIPTION
This switches the compiler we use from GHC 8.0.1 to GHC 8.0.2 without changing any versions of dependencies. I was planning to update some dependency versions later, probably once purescript 0.10.6 and Stackage LTS 8 are out.

Fixes #278.