### PR TITLE
Update to purescript 0.10.7

### DIFF
--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -100,7 +100,7 @@ library
                  , containers
                  , vector
                  , time
-                 , purescript >= 0.10.0
+                 , purescript >= 0.10.7
                  , bower-json >= 1.0.0.1
                  , blaze-builder
                  , blaze-markup

--- a/src/Handler/Utils.hs
+++ b/src/Handler/Utils.hs
@@ -21,9 +21,9 @@ internalServerError = sendResponseStatus internalServerError500 ("" :: Text)
 getDataDir :: Handler String
 getDataDir = appDataDir . appSettings <$> getYesod
 
--- | Read the file at the given path as a lazy ByteString, or return Nothing
+-- | Read the file at the given path as a strict ByteString, or return Nothing
 -- if no such file exists.
-readFileMay :: (IOData a) => FilePath -> IO (Maybe a)
+readFileMay :: FilePath -> IO (Maybe ByteString)
 readFileMay file =
   catchDoesNotExist (readFile file)
 
@@ -37,7 +37,7 @@ catchDoesNotExist act =
     | isDoesNotExistErrorType (ioeGetErrorType e) = Just ()
     | otherwise = Nothing
 
-writeFileWithParents :: (IOData a, MonadIO m) => FilePath -> a -> m ()
+writeFileWithParents :: MonadIO m => FilePath -> ByteString -> m ()
 writeFileWithParents file contents = liftIO $ do
   createDirectoryIfMissing True (takeDirectory file)
   writeFile file contents

--- a/src/Import/NoFoundation.hs
+++ b/src/Import/NoFoundation.hs
@@ -2,7 +2,7 @@ module Import.NoFoundation
     ( module Import
     ) where
 
-import ClassyPrelude.Yesod   as Import hiding (Handler)
+import ClassyPrelude.Yesod   as Import
 import Settings              as Import
 import Yesod.Core.Types      as Import (loggerSet)
 import Yesod.Default.Config2 as Import

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -85,15 +85,14 @@ getAppSettings = do
   appGithubAuthToken <- map (GithubAuthToken . fromString) <$> env "GITHUB_AUTH_TOKEN"
   when (isNothing appGithubAuthToken) $
     let message = "No GitHub auth token configured (environment variable is: PURSUIT_GITHUB_AUTH_TOKEN)"
-        pErr = hPutStrLn stderr :: Text -> IO ()
     in if isDevelopment
       then do
-        pErr ("[Warn] " <> message)
-        pErr  "[Warn] Requests to the GitHub API will be performed with no authentication."
-        pErr  "[Warn] This will probably result in rate limiting."
+        sayErr ("[Warn] " <> message)
+        sayErr  "[Warn] Requests to the GitHub API will be performed with no authentication."
+        sayErr  "[Warn] This will probably result in rate limiting."
       else do
-        pErr ("[Error] " <> message)
-        pErr  "[Error] Refusing to run in production mode."
+        sayErr ("[Error] " <> message)
+        sayErr  "[Error] Refusing to run in production mode."
         exitFailure
 
   appMinimumCompilerVersion <- envP parseVersion' "MINIMUM_COMPILER_VERSION" .!= Version [0,0,0,0] []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,13 +1,18 @@
-resolver: lts-7.14
-compiler: ghc-8.0.2
+resolver: lts-8.0
 flags:
   pursuit:
     dev: true
 packages:
 - '.'
 extra-deps:
+- aeson-0.11.3.0
 - barrier-0.1.1
-- purescript-0.10.6
-- bower-json-1.0.0.1
+- directory-1.2.7.1
+- http-client-0.4.31.2
+- http-client-tls-0.2.4.1
+- http-conduit-2.1.11
 - optparse-applicative-0.13.0.0
-- turtle-1.3.1
+- pipes-4.2.0
+- pipes-http-1.0.5
+- purescript-0.10.7
+- websockets-0.9.8.2


### PR DESCRIPTION
Also update to LTS 8. The latest ClassyPrelude stopped exporting `IOData` which necessitated making a few minor changes / switching lazy bytestrings for strict ones (which is probably what we should be doing anyway, as these json blobs are all going to be pretty small).