### PR TITLE
Improve compareTypes algorithm.

### DIFF
--- a/src/Handler/Search.hs
+++ b/src/Handler/Search.hs
@@ -105,7 +105,7 @@ searchForType ty = do
     -- or Nothing otherwise. Lower scores are better.
     compareTypes :: P.Type -> P.Type -> Maybe Int
     compareTypes (P.TypeVar _) (P.TypeVar _) = Just 0
-    compareTypes t (P.TypeVar _) = Just (typeComplexity t)
+    compareTypes t (P.TypeVar _) = Just (1 + typeComplexity t)
     compareTypes (P.TypeLevelString s1) (P.TypeLevelString s2) | s1 == s2 = Just 0
     compareTypes (P.TypeWildcard _) t = Just (typeComplexity t)
     compareTypes (P.TypeConstructor q1) (P.TypeConstructor q2) | compareQual q1 q2 = Just 0


### PR DESCRIPTION
addresses #132

Comparisons between `TypeVar`s and something that is _not_ a type variable should be penalized by at least 1 point. This ensures that a query like `Char -> String` only awards a 0 point result to the correct `singleton` function, or that `Int -> Number` yields `toNumber` first.

(previously, matches including type variables like `forall a b. a -> b` would be rewarded 0 points for both of these queries.)