### PR TITLE
Use purescript-0.11.3

### DIFF
--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -1,5 +1,5 @@
 name:              pursuit
-version:           0.5.0
+version:           0.6.0
 cabal-version:     >= 1.8
 build-type:        Simple
 license:           MIT
@@ -99,7 +99,7 @@ library
                  , containers
                  , vector
                  , time
-                 , purescript >= 0.11.1
+                 , purescript >= 0.11.3
                  , bower-json >= 1.0.0.1
                  , blaze-builder
                  , blaze-markup

--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -86,7 +86,7 @@ library
                  , directory                     >= 1.1        && < 1.3
                  , warp                          >= 3.0        && < 4
                  , data-default
-                 , aeson                         >= 0.11       && < 0.12
+                 , aeson
                  , conduit                       >= 1.0        && < 2.0
                  , monad-logger                  >= 0.3        && < 0.4
                  , fast-logger                   >= 2.2        && < 2.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -14,5 +14,5 @@ extra-deps:
 - optparse-applicative-0.13.2.0
 - pipes-4.2.0
 - pipes-http-1.0.5
-- purescript-0.11.1
+- purescript-0.11.3
 - websockets-0.9.8.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ flags:
 packages:
 - '.'
 extra-deps:
-- aeson-0.11.3.0
+- aeson-1.0.2.1
 - barrier-0.1.1
 - directory-1.2.7.1
 - http-client-0.4.31.2


### PR DESCRIPTION
I thought this would fix the issue I saw when uploading `arrays`:

```
* At the path: ["modules"][0]["declarations"][19]["info"]["type"]
Arising from an Aeson FromJSON instance:
key "contents" not present
```

assuming it was caused by [my recent PR](https://github.com/purescript/purescript/commit/c82defc6f1ded53f42a49c7507561ef1feb6a359).

But now I see that change has been around since 0.11.0, so would have been in the previous Pursuit build. Also, I don't think I touched any code which would affect that path in the JSON, although I might be mistaken.

Any thoughts, @hdgarrood?