### PR TITLE
Better 'package not found' message

### DIFF
--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -255,3 +255,8 @@ displayJsonError value e = case e of
         ]
       _ ->
         []
+
+versionSeries :: Version -> String
+versionSeries (Version (0:x:_) _) = "0." ++ show x ++ ".x"
+versionSeries (Version (x:_) _) = show x ++ ".x"
+versionSeries _ = "*"

--- a/templates/packageNotFound.hamlet
+++ b/templates/packageNotFound.hamlet
@@ -4,7 +4,6 @@
   No package named
   <strong>
     #{runPackageName pkgName}
-  exists in the database. If you think this is an error, please let us know
-  by
-  <a href="https://github.com/purescript/pursuit/issues">opening an issue#
-  \, or visiting us on #purescript IRC on Freenode.
+  exists in the database. It might not have been published to Pursuit as of the
+  currently active version series of the PureScript compiler (namely,
+  #{versionSeries P.version}).


### PR DESCRIPTION
An example of the message this might now generate:

>  It might not have been published to Pursuit as of the currently active version series of the PureScript compiler (namely, 0.11.x).

I think this is an improvement as the current message suggests that there might be a bug in Pursuit, which has turned out to almost never be the case; rather, it's almost always because the package hasn't been reuploaded since the last breaking change.