### PR TITLE
Add publish date to package pages

### DIFF
--- a/src/TemplateHelpers.hs
+++ b/src/TemplateHelpers.hs
@@ -4,6 +4,7 @@ import Import hiding (span)
 import qualified Data.List.Split as List
 import Data.Version (Version)
 import Data.Text (splitOn)
+import Data.Time.Format as TimeFormat
 import Text.Blaze.Html5 as H hiding (map, link)
 import Text.Blaze.Html5.Attributes as A hiding (span, name, start)
 import qualified Web.Bower.PackageMeta as Bower
@@ -215,3 +216,9 @@ getFragmentRender :: Handler ((Route App, Maybe Text) -> Text)
 getFragmentRender = do
   render <- getUrlRender
   return $ \(route, fragment) -> render route ++ maybe "" ("#" ++) fragment
+
+formatDate :: UTCTime -> String
+formatDate =
+  TimeFormat.formatTime
+    TimeFormat.defaultTimeLocale
+    (TimeFormat.iso8601DateFormat Nothing)

--- a/templates/packageVersion.hamlet
+++ b/templates/packageVersion.hamlet
@@ -13,6 +13,9 @@
       <dd .grouped-list__item>#{licenses}
     <dt .grouped-list__title>Uploaded by
     <dd .grouped-list__item>#{linkToGithubUser pkgUploader}
+    $maybe date <- pkgTagTime
+      <dt .grouped-list__title>Published on
+      <dd .grouped-list__item>#{formatDate date}
 
   #{renderReadme ereadme}
 


### PR DESCRIPTION
Fixes #216

Example appearance:
![screenshot from 2017-07-10 21-23-15](https://user-images.githubusercontent.com/1270186/28038267-3cb435ac-65b6-11e7-90a6-d55f6bacfe96.png)

Uses ISO8601 date format, because e.g. 01/02/2017 is ambiguous.
