### PR TITLE
Redirect URLs without a version to the latest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - mkdir -p ~/.local/bin
   - export PATH=$HOME/.local/bin:$PATH
   - curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  - stack setup
   - stack --version
   - stack install alex happy
 

--- a/config/routes
+++ b/config/routes
@@ -9,6 +9,7 @@
 /packages/#PathPackageName/#PathVersion                PackageVersionR             GET
 /packages/#PathPackageName/#PathVersion/docs           PackageVersionDocsR         GET
 /packages/#PathPackageName/#PathVersion/docs/#Text     PackageVersionModuleDocsR   GET
+!/packages/#PathPackageName/docs/#Text                 PackageModuleDocsR          GET
 !/packages/#PathPackageName/badge                      PackageBadgeR               GET
 !/packages/#PathPackageName/available-versions         PackageAvailableVersionsR   GET
 

--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -46,12 +46,22 @@ getHomeR =
         pkgNamesByLetter = groupBy ((==) `on` (firstLetter )) pkgNames
     defaultLayout $(widgetFile "homepage")
 
-getPackageR :: PathPackageName -> Handler Html
-getPackageR ppkgName@(PathPackageName pkgName) = do
+latestVersionOr404 :: PackageName -> Handler Version
+latestVersionOr404 pkgName = do
   v <- getLatestVersionFor pkgName
   case v of
     Nothing -> packageNotFound pkgName
-    Just v' -> redirect (PackageVersionR ppkgName (PathVersion v'))
+    Just v' -> pure v'
+
+getPackageR :: PathPackageName -> Handler Html
+getPackageR ppkgName@(PathPackageName pkgName) = do
+  v <- latestVersionOr404 pkgName
+  redirect (PackageVersionR ppkgName (PathVersion v))
+
+getPackageModuleDocsR :: PathPackageName -> Text -> Handler Html
+getPackageModuleDocsR ppkgName@(PathPackageName pkgName) mnString = do
+  v <- latestVersionOr404 pkgName
+  redirect (PackageVersionModuleDocsR ppkgName (PathVersion v) mnString)
 
 getPackageAvailableVersionsR :: PathPackageName -> Handler Value
 getPackageAvailableVersionsR (PathPackageName pkgName) =

--- a/travis-script.sh
+++ b/travis-script.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-timeout 40m stack --no-terminal --jobs=1 --install-ghc build --only-dependencies
+timeout 40m stack --no-terminal --jobs=1 build --only-dependencies
 ret=$?
 case "$ret" in
   0)


### PR DESCRIPTION
Fixes #277

I tested this and it does include the fragment too, so e.g. if you use the URL that @garyb gave

> https://pursuit.purescript.org/packages/purescript-halogen/docs/Halogen.Query#v:action

it does focus on `action` after redirecting to the page with the latest version. :tada: