### PR TITLE
WIP: Implement search results pagination

### DIFF
--- a/static/css/pursuit.css
+++ b/static/css/pursuit.css
@@ -619,6 +619,18 @@ ol li {
 .result__actions__item + .result__actions__item {
   margin-left: 0.65em;
 }
+/* Component: Pagination
+ * -------------------------------------------------------------------------- */
+ul.pagination li {
+  float: left;
+  padding-left: 0.6em;
+}
+ul.pagination li.active {
+  text-decoration: underline;
+}
+ul.pagination li::before {
+  content: inherit;
+}
 /* Component: Version Selector
  * -------------------------------------------------------------------------- */
 .version-selector {

--- a/templates/pagination.hamlet
+++ b/templates/pagination.hamlet
@@ -1,0 +1,21 @@
+<ul .pagination>
+    <li .previous :not hasPrevPage:.disabled>
+        $if hasPrevPage
+            <a href="#{mkPageLink $ page - 1}">
+                &larr;
+        $else
+            <span .disabled>
+              &larr;
+
+    $forall p <- allPages
+        <li :p == page:.active>
+            <a href="#{mkPageLink p}">
+                #{show p}
+
+    <li .next :not hasNextPage:.disabled>
+        $if hasNextPage
+            <a href="#{mkPageLink $ page + 1}">
+                &rarr;
+        $else
+            <span>
+              &rarr;

--- a/templates/search.hamlet
+++ b/templates/search.hamlet
@@ -1,6 +1,9 @@
 <div .col.col--main>
   <h1>Search results
 
+  $maybe paginationW <- mPaginationW
+    ^{paginationW}
+
   $if null results
     <div .result.result--empty>
       Your search for <strong>#{query}</strong> did not yield any results.
@@ -44,3 +47,7 @@
           <span .result__actions__item>
             <span .badge.badge--module title="Module">M
             #{moduleName}
+
+  $maybe paginationW <- mPaginationW
+    ^{paginationW}
+


### PR DESCRIPTION
Stab at #305

It's working but the HTML is pretty horrifying for large result sets as there's a link to every single page in the navigation bar. I was thinking this would be a nice way to render the navigation: https://stackoverflow.com/a/14193775/2954634?

Also, in order to know the total amount of pages, I removed the [`take 50`](https://github.com/purescript/pursuit/blob/c16211e916b52f446d9f7ae4dce967629ffac0d5/src/Handler/Search.hs#L90), so it's doing a lot more work now in case of large result sets. If so desired, we could simply take 51, then check if the result is greater than 50, then simply render a "next" link, as opposed to individual page links.

Would be great to get some feedback on the above so I can adjust the code accordingly