### PR TITLE
Fix source links for re-exports

### DIFF
--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -34,10 +34,8 @@ instance Read PathPackageName where
       Left _ -> []
 
 instance PathPiece PathPackageName where
-  toPathPiece =
-    runPackageName . runPathPackageName
-  fromPathPiece =
-    fmap PathPackageName . either (const Nothing) Just . parsePackageName
+  toPathPiece = runPackageName . runPathPackageName
+  fromPathPiece = fmap PathPackageName . hush . parsePackageName
 
 newtype PathVersion =
   PathVersion { runPathVersion :: Version }

--- a/src/Handler/Database.hs
+++ b/src/Handler/Database.hs
@@ -56,7 +56,7 @@ getAllPackages = do
   catMaybes <$> traverse lookupPackageMay pkgNamesAndVersions
   where
   withVersion name = (map . map) (name,) (getLatestVersionFor name)
-  lookupPackageMay = map (either (const Nothing) Just) . uncurry lookupPackage
+  lookupPackageMay = map hush . uncurry lookupPackage
 
 tryStripPrefix :: Text -> Text -> Text
 tryStripPrefix pre s = fromMaybe s (T.stripPrefix pre s)

--- a/src/Handler/Search.hs
+++ b/src/Handler/Search.hs
@@ -43,9 +43,7 @@ getSearchR = do
     jsonOutput = fmap toJSON . traverse searchResultToJSON
 
     tryParseType :: Text -> Maybe P.Type
-    tryParseType = hush (P.lex "") >=> hush (P.runTokenParser "" (P.parsePolyType <* Parsec.eof))
-      where
-        hush f = either (const Nothing) Just . f
+    tryParseType = hush . (P.lex "") >=> hush . (P.runTokenParser "" (P.parsePolyType <* Parsec.eof))
 
     isSimpleType :: P.Type -> Bool
     isSimpleType P.TypeVar{} = True

--- a/src/Import/NoFoundation.hs
+++ b/src/Import/NoFoundation.hs
@@ -1,5 +1,6 @@
 module Import.NoFoundation
     ( module Import
+    , hush
     ) where
 
 import ClassyPrelude.Yesod   as Import
@@ -7,3 +8,6 @@ import Settings              as Import
 import Yesod.Core.Types      as Import (loggerSet)
 import Yesod.Default.Config2 as Import
 import Control.Category      as Import ((>>>), (<<<))
+
+hush :: Either a b -> Maybe b
+hush = either (const Nothing) Just


### PR DESCRIPTION
Fixes #304 

There's a potentially blocking caveat to this solution that I have not found a way around: In order to render source links for re-exports, we need to load the `VerifiedPackage` for every dependency. And since the `packageAsHtml` is pure, we have to create a lookup map prematurely, rather than on demand. Would be simple join to get this info if we had a database out the back, but now it's one file read per dependency.