### PR TITLE
Add Prim to homepage

### DIFF
--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -8,7 +8,7 @@
     Pursuit hosts API documentation for <a href="http://www.purescript.org/">PureScript</a> packages. It lets you search by package, module, and function names, as well as approximate type signatures.
 
   <p>
-    To get started, have a look around the <a href="/packages/purescript-prelude">Prelude</a>, or try one of these example searches:
+    To get started, have a look around <a href=@{BuiltinDocsR "Prim"}>Prim</a>, the <a href="/packages/purescript-prelude">Prelude</a>, or try one of these example searches:
 
   <ul .ul--search>
     <li><a href="/search?q=map">map</a></li>
@@ -27,12 +27,6 @@
     <dd .grouped-list__item>
       Pursuit is free and open-source software, and the code is hosted on GitHub.
       Contributions are welcome: <a href="https://github.com/purescript/pursuit">https://github.com/purescript/pursuit</a>.
-
-  <dl .grouped-list>
-    <dt .grouped-list__title>Prim
-    <dd .grouped-list__item>
-      <a href=@{BuiltinDocsR "Prim"}>Prim</a> is a module which is built into
-      the compiler; it does not exist in any package.
 
 <div .clear-floats>
   <h2>Package Index

--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -28,6 +28,12 @@
       Pursuit is free and open-source software, and the code is hosted on GitHub.
       Contributions are welcome: <a href="https://github.com/purescript/pursuit">https://github.com/purescript/pursuit</a>.
 
+  <dl .grouped-list>
+    <dt .grouped-list__title>Prim
+    <dd .grouped-list__item>
+      <a href=@{BuiltinDocsR "Prim"}>Prim</a> is a module which is built into
+      the compiler; it does not exist in any package.
+
 <div .clear-floats>
   <h2>Package Index
   $if null pkgNames


### PR DESCRIPTION
N.B. I haven't tried to run this. But I wanted to throw this out for discussion/opinion.

Should address #291.

Currently, there's no link at all to this page on Pursuit, any other PureScript website, or any other PureScript GitHub repo. What that means is that unless you're in the know, you can't find the page. I get that search results would be really great to have, but that shouldn't prevent anyone in the community from finding these docs.

I'm not saying this is the greatest thing ever, and I know it can be improved. But, this gets us from zero to nonzero, which is more valuable than being stuck trying to go from zero to ten.