### PR TITLE
Add RSS feed for latest packages

### DIFF
--- a/config/routes
+++ b/config/routes
@@ -12,6 +12,7 @@
 !/packages/#PathPackageName/docs/#Text                 PackageModuleDocsR          GET
 !/packages/#PathPackageName/badge                      PackageBadgeR               GET
 !/packages/#PathPackageName/available-versions         PackageAvailableVersionsR   GET
+/packages-latest                                       PackagesLatestR             GET
 
 /builtins/docs/#Text                                   BuiltinDocsR                GET
 

--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -69,6 +69,7 @@ library
                  , yesod-core                    >= 1.4.6      && < 1.5
                  , yesod-static                  >= 1.4.0.3    && < 1.6
                  , yesod-form                    >= 1.4.0      && < 1.5
+                 , yesod-newsfeed
                  , classy-prelude                >= 0.10.2
                  , classy-prelude-conduit        >= 0.10.2
                  , classy-prelude-yesod          >= 0.10.2

--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -46,6 +46,36 @@ getHomeR =
         pkgNamesByLetter = groupBy ((==) `on` (firstLetter )) pkgNames
     defaultLayout $(widgetFile "homepage")
 
+getPackagesLatestR :: Handler TypedContent
+getPackagesLatestR = do
+  latest <- getLatestPackages
+  now <- liftIO getCurrentTime
+  let
+    toEntry (name, version, time) =
+      let pkgname = runPackageName name
+          pkgversion = pack (showVersion version)
+      in
+        FeedEntry
+        { feedEntryLink = PackageVersionR (PathPackageName name) (PathVersion version)
+        , feedEntryUpdated = time
+        , feedEntryTitle = pkgname <> " " <> pkgversion
+        , feedEntryContent = toHtml ("" :: Text)
+        , feedEntryEnclosure = Nothing
+        }
+    feed =
+      Feed
+      { feedTitle = "Latest PureScript Packages"
+      , feedLinkSelf = PackagesLatestR
+      , feedLinkHome = HomeR
+      , feedAuthor = "purescript.org"
+      , feedDescription = toHtml ("Latest PureScript Packages" :: Text)
+      , feedLanguage = "en"
+      , feedUpdated = now
+      , feedLogo = Just (StaticR favicon_favicon_32x32_png, "logo")
+      , feedEntries = map toEntry latest
+      }
+  newsFeed feed
+
 latestVersionOr404 :: PackageName -> Handler Version
 latestVersionOr404 pkgName = do
   v <- getLatestVersionFor pkgName

--- a/templates/homepage.hamlet
+++ b/templates/homepage.hamlet
@@ -37,7 +37,7 @@
       <div .multi-col__col>
         <h3>Latest uploads
         <ul>
-          $forall (pkgName, version) <- latest
+          $forall (pkgName, version, _) <- latest
             <li>
               <div .deplink>
                 <a .deplink__link href=@{PackageVersionR (PathPackageName pkgName) (PathVersion version)}>#{runPackageName pkgName}


### PR DESCRIPTION
Hi, I use RSS quite a bit and thought Pursuit ought to have a feed for the latest uploaded packages - I'd like my feed reader to tell me of updates :)

This PR adds a RSS feed at `/latest-packages` which lists the same packages that are displayed on the homepage.  It uses the `yesod-newsfeed` library which integrates well with the existing Yesod app.  There are two outstanding things that I've noted below:

1. Where should the link to the RSS feed go?
    - Ideally it should be embedded in the `head` tag on the homepage and also as an icon on the homepage somewhere.  Is there a way to conditionally include the link in `head` only if the layout template is processing on the homepage?
2. Caching the RSS feed
    - It's probably a good idea to cache the feed but I'm unsure how to go about doing so.  I had a look at `src/Handler/Caching.hs` but wasn't sure how to go about turning the `TypedContent` feed into a ByteString.  I'm unfamiliar with Yesod but happy to dig in if given some pointers.