### PR TITLE
'Load more' button for search results (fixes #305)

### DIFF
--- a/static/js/Pursuit.js
+++ b/static/js/Pursuit.js
@@ -121,8 +121,56 @@ function initializeSearchForm() {
   }
 }
 
+function initializeLoadMoreLink(opts) {
+  var link = document.getElementById('load-more-link')
+  var results = document.getElementById('results-container')
+  function makeOnClickHandler(url) {
+    link.removeAttribute('data-load-more-url')
+    return function() {
+      var req = new XMLHttpRequest()
+      req.open('GET', url, true)
+      req.responseType = "document"
+      req.onload = function() {
+        var container = this.responseXML.getElementById('results-container')
+        var children = container.childNodes
+        var loadMoreUrl, status, msg, pEl
+        for (var i = 0; i < children.length; i++) {
+          results.appendChild(children[i])
+        }
+        if (loadMoreUrl = req.getResponseHeader("X-Load-More")) {
+          link.onclick = makeOnClickHandler(loadMoreUrl)
+        } else {
+          status = req.getResponseHeader("X-No-More")
+          switch (status) {
+            case "limited":
+              msg = "Further results have been omitted."
+              break;
+            case "exhausted":
+              msg = "No further results."
+              break;
+            default:
+              msg = "There are no more results, but the server did not appear to indicate why."
+          }
+          link.remove()
+          loadMoreDiv = document.getElementById('load-more')
+          pEl = document.createElement("p")
+          pEl.appendChild(document.createTextNode(msg))
+          loadMoreDiv.appendChild(pEl)
+        }
+      }
+      req.send(null)
+    }
+  }
+  var url = link.getAttribute('data-load-more-url')
+  if (url) {
+    link.onclick = makeOnClickHandler(url)
+    link.href = 'javascript:void(0)'
+  }
+}
+
 window.Pursuit = {
   initializeVersionSelector: initializeVersionSelector,
   initializeSearchForm: initializeSearchForm,
+  initializeLoadMoreLink: initializeLoadMoreLink
 }
 })()

--- a/templates/search.hamlet
+++ b/templates/search.hamlet
@@ -4,43 +4,13 @@
   $if null results
     <div .result.result--empty>
       Your search for <strong>#{query}</strong> did not yield any results.
-  $forall r <- results
-    <div .result>
-      <h3 .result__title>
-        $case hrInfo r
-          $of PackageResult
-            <span .result__badge.badge.badge--package title="Package">P
-            <a .result__link href=#{fr $ routeResult r}>
-              #{Bower.runPackageName $ hrPkgName r}
-          $of ModuleResult moduleName
-            <span .badge.badge--module title="Module">M
-            <a .result__link href=#{fr $ routeResult r}>
-              #{moduleName}
-          $of DeclarationResult _ _ name _
-            <a .result__link href=#{fr $ routeResult r}>
-              #{name}
-
-    <div .result__body>
-      $case hrInfo r
-        $of PackageResult
-        $of ModuleResult _
-        $of DeclarationResult _ _ name typ
-          $maybe typeValue <- typ
-            <pre .result__signature><code>#{name} :: #{typeValue}</code></pre>
-
-      #{renderMarkdownNoLinks $ hrComments r}
-
-    <div .result__actions>
-      $case hrInfo r
-        $of PackageResult
-        $of ModuleResult _
-          <span .result__actions__item>
-            <span .badge.badge--package title="Package">P
-            #{Bower.runPackageName $ hrPkgName r}
-        $of DeclarationResult _ moduleName _ _
-          <span .result__actions__item>
-            <span .badge.badge--package title="Package">P
-            #{Bower.runPackageName $ hrPkgName r}
-          <span .result__actions__item>
-            <span .badge.badge--module title="Module">M
-            #{moduleName}
+  <div #results-container>
+    $forall r <- results
+      ^{searchResultHtml fr r}
+  $if not (null results)
+    <div #load-more .load_more>
+      $maybe nextUrl <- relatedUrlsNext urls
+        <a #load-more-link href="#{nextUrl}" data-load-more-url="#{fromMaybe "" (relatedUrlsPartial urls)}">
+          Load more results
+      $nothing
+        <p>No further results.

--- a/templates/search.julius
+++ b/templates/search.julius
@@ -1,0 +1,1 @@
+window.Pursuit.initializeLoadMoreLink()

--- a/templates/search.lucius
+++ b/templates/search.lucius
@@ -1,0 +1,12 @@
+.load_more {
+  margin-top: 2em;
+}
+
+.load_more p {
+  font-style: italic;
+}
+
+.load_more a {
+  background: #eee;
+  padding: 0.4em;
+}


### PR DESCRIPTION
If there are more search results than fit in one 'page' (= 50 results),
Pursuit now displays a 'load more' link at the end of the results;
clicking this loads another page of results via AJAX and appends them to
the document. If JavaScript is disabled, the 'load more' link instead
loads the same page, except with another 50 results (or however many
remaining results there are, if less than 50).

We distinguish the cases where there are no more results vs where
Pursuit has decided not to show any more results (for the sake of
minimising load on the server) by displaying an explanatory message at
the end of the search results.

The JSON output only contains up to 50 results, so subsequent pages of
results must be fetched with a new request.

We also include a Link header in the response, referencing the next and
previous URLs, mainly for clients using JSON (although clients using
HTML might find it useful too).