### PR TITLE
Include Prim entries in search results (fixes #265)

### DIFF
--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -56,14 +56,21 @@ instance PathPiece VerificationKey where
 
 -- | A single search result.
 data SearchResult = SearchResult
-  { hrPkgName    :: PackageName
-  , hrPkgVersion :: Version
-  , hrComments   :: Text
-  , hrInfo       :: SearchResultInfo
+  { srSource   :: SearchResultSource
+  , srComments :: Text
+  , srInfo     :: SearchResultInfo
   }
   deriving (Show, Eq, Generic)
 
 instance NFData SearchResult
+
+-- | Tells you where a search result came from.
+data SearchResultSource
+  = SourceBuiltin
+  | SourcePackage PackageName Version
+  deriving (Show, Eq, Generic)
+
+instance NFData SearchResultSource
 
 data SearchResultInfo
   = PackageResult

--- a/src/Handler/Database.hs
+++ b/src/Handler/Database.hs
@@ -74,7 +74,15 @@ fromText = TE.encodeUtf8
 createDatabase :: Handler (Trie.Trie [(SearchResult, Maybe P.Type)])
 createDatabase = do
   pkgs <- getAllPackages
-  return . fromListWithDuplicates $ concatMap entriesForPackage pkgs
+  return . fromListWithDuplicates $
+    primEntries ++ concatMap entriesForPackage pkgs
+
+primEntries :: [(ByteString, (SearchResult, Maybe P.Type))]
+primEntries =
+  let
+    mkResult = SearchResult SourceBuiltin
+  in
+    entriesForModule mkResult D.primDocsModule
 
 entriesForPackage ::
   D.Package a ->
@@ -82,7 +90,7 @@ entriesForPackage ::
 entriesForPackage D.Package{..} =
   let
     mkResult =
-      SearchResult (bowerName pkgMeta) pkgVersion
+      SearchResult (SourcePackage (bowerName pkgMeta) pkgVersion)
     packageEntry =
       ( fromText (tryStripPrefix "purescript-" (T.toLower (runPackageName (bowerName pkgMeta))))
       , ( mkResult (fromMaybe "" (bowerDescription pkgMeta))


### PR DESCRIPTION
I've tried to avoid breaking the JSON search results format as much as possible, but this could cause problems for IDE plugins. Here's what a `Prim` result looks like:

```
{
  "text":"<p>A 32-bit signed integer. See the purescript-integers package for details\nof how this is accomplished when compiling to JavaScript.</p>\n<p>Construct values of this type with literals:</p>\n<pre><code>x = 23 :: Int\n</code></pre>\n",
  "markup":"<p>A 32-bit signed integer. See the purescript-integers package for details\nof how this is accomplished when compiling to JavaScript.</p>\n<p>Construct values of this type with literals:</p>\n<pre><code>x = 23 :: Int\n</code></pre>\n",
  "url":"http://localhost:3000/builtins/docs/Prim#t:Int",
  "version":"0.11.7",
  "package":"<builtin>",
  "info":{
   "typeOrValue":"TypeLevel",
    "module":"Prim",
    "typeText":null,
    "title":"Int",
    "type":"declaration"
  }
}
```

/cc @kRITZCREEK @nwolverson @FrigoEU @coot (have I missed any ide plugin maintainers here?)