### PR TITLE
Allow child declarations to be found by type

### DIFF
--- a/src/Handler/Database.hs
+++ b/src/Handler/Database.hs
@@ -153,7 +153,7 @@ entriesForDeclaration mkResult modName D.Declaration{..} =
                               (P.runModuleName modName)
                               cdeclTitle
                               (fmap typeToText ty'))
-               , Nothing
+               , ty'
                )
              )
 


### PR DESCRIPTION
Fixes #303. `(a -> b) -> f a -> f b` now finds `map` (and `cmap`), and `a -> Maybe a` now finds `Just`.

Also refs #342.