### PR TITLE
New help pages

### DIFF
--- a/src/Handler/Help.hs
+++ b/src/Handler/Help.hs
@@ -36,25 +36,25 @@ helpLayout forWhom inner =
     <div .col.col--aside>
       <dl .grouped-list>
         <dt .grouped-list__title>
-          Contents
+          Overview
         <dd .grouped-list__item>
           <a href="/help">Help index
+      <dl .grouped-list>
+        <dt .grouped-list__title>
+          Pursuit users
         <dd .grouped-list__item>
-          <a href="/help/users">Pursuit users
-          <ul>
-            <li>
-              <a href="/help/users#searching">
-                Searching
+          <a href="/help/users#searching">
+            Searching
+      <dl .grouped-list>
+        <dt .grouped-list__title>
+          Package authors
         <dd .grouped-list__item>
-          <a href="/help/authors">Package authors
-          <ul>
-            <li>
-              <a href="/help/authors#submitting-packages">
-                How to submit packages
-            <li>
-              <a href="/help/authors#submit-automated">
-                Submitting packages from a script
-            <li>
-              <a href="/help/authors#package-badges">
-                Package badges
+          <a href="/help/authors#submitting-packages">
+            How to submit packages
+        <dd .grouped-list__item>
+          <a href="/help/authors#submit-automated">
+            Submitting packages from a script
+        <dd .grouped-list__item>
+          <a href="/help/authors#package-badges">
+            Package badges
     |]

--- a/static/help-docs/authors.md
+++ b/static/help-docs/authors.md
@@ -6,7 +6,7 @@
 
 3. Authenticate to GitHub by running `pulp login`. (This is necessary in order for us to be able to tell who uploaded which packages).
 
-4. Change to your project directory and run `pulp publish`. This will register your package on Bower if necessary, push commits and the relevant tag to your "origin" Git remote, and then generate your documentation and upload it to Pursuit.
+4. Change to your project directory and run `pulp publish`. This will register your package on Bower if necessary, push commits and the relevant tag to your “origin” Git remote, and then generate your documentation and upload it to Pursuit.
 
    `pulp publish` also accepts a `--no-push` flag which skips the Bower registration check as well as pushing commits (this is useful for uploading other people's packages, if you ever need to do this). There is also a `--push-to` option which allows you to specify a different Git remote to push tags and commits to.
 

--- a/static/help-docs/authors.md
+++ b/static/help-docs/authors.md
@@ -1,4 +1,4 @@
-## How to submit packages <a name="submitting-packages"></a>
+## <a name="submitting-packages"></a>How to submit packages
 
 1. Put the code up on GitHub. (Currently, GitHub is the only supported hosting method. If you'd rather host your code somewhere else, please open an issue and let us know).
 
@@ -13,7 +13,7 @@
 
 Your package, together with documentation, should now appear in Pursuit.
 
-## Submitting packages from a script <a name="submit-automated"></a>
+## <a name="submit-automated"></a>Submitting packages from a script
 
 You can also use Pulp to submit packages from a script. Pulp prompts for confirmation when you run `pulp publish`, so you will need to use a program like `yes` to answer affirmatively.
 
@@ -41,7 +41,7 @@ curl -X POST \
 
 If your submission is successful, Pursuit will return a 201 Created response, and the URL for your newly uploaded package will be in the Location header.
 
-## Package badges <a name="package-badges"></a>
+## <a name="package-badges"></a>Package badges
 
 Pursuit can generate SVG badges for your packages, which you can put on your project's homepage, or perhaps its GitHub readme.
 

--- a/static/help-docs/users.md
+++ b/static/help-docs/users.md
@@ -10,20 +10,20 @@ which has been uploaded to Pursuit. This is the most common type of search
 result. It includes types, values (note: functions are values), data
 constructors, type synonyms, type classes, kinds, and so on. For example:
 
-* the query "const" will return the [`const`][] function in the results,
-* the query "Unit" will return the [`Unit`][] type in the results, and
-* the query "applicative" will return the [`Applicative`][] type class in the
+* the query “const” will return the [`const`][] function in the results,
+* the query “Unit” will return the [`Unit`][] type in the results, and
+* the query “applicative” will return the [`Applicative`][] type class in the
   results.
 
 Searching using prefixes of the desired result's name also works; for example,
-the query "sequen" returns the [`sequence`][] function.
+the query “sequen” returns the [`sequence`][] function.
 
 You can also search for declarations based on their type. For example, the type
-of [`const`][] is `forall a b. a -> b -> a`; if you search for "a -> b -> a",
+of [`const`][] is `forall a b. a -> b -> a`; if you search for “a -> b -> a”,
 then `const` will appear in the search results.
 
 When searching by type, Pursuit knows that the names you give to the type
-variables do not matter. For example, the query "x -> y -> x" also returns
+variables do not matter. For example, the query “x -> y -> x” also returns
 `const` in the results.
 
 ### Modules
@@ -35,10 +35,10 @@ repository][].
 To search for a module, enter either the whole module name or a prefix of it.
 For example:
 
-- the query "Control.Plus" returns the module `Control.Plus`,
-- the query "Data.String" returns the module `Data.String`, as well as
+- the query “Control.Plus” returns the module `Control.Plus`,
+- the query “Data.String” returns the module `Data.String`, as well as
   `Data.String.Base64`, `Data.String.CaseInsensitive`, and so on, and
-- the query "DOM" returns the module `DOM`, as well as all of the other modules
+- the query “DOM” returns the module `DOM`, as well as all of the other modules
   which begin with `DOM`.
 
 ### Packages
@@ -48,12 +48,12 @@ intended to be used together. Packages also have metadata attached to them such
 as their author, version, publish date, and so on.
 
 To search for a package, simply enter its name or a prefix of it. It is not
-necessary to include the "purescript-" prefix. For example:
+necessary to include the “purescript-” prefix. For example:
 
-* the query "lazy" returns the package `purescript-lazy`,
-* the query "strings" returns the packages `purescript-strings` and
+* the query “lazy” returns the package `purescript-lazy`,
+* the query “strings” returns the packages `purescript-strings` and
   `purescript-strings-extra`, and
-* the query "argonaut" returns the packages `purescript-argonaut`,
+* the query “argonaut” returns the packages `purescript-argonaut`,
   `purescript-argonaut-codecs`, `purescript-argonaut-core`, and so on.
 
 ### Types of searches
@@ -64,13 +64,13 @@ Only declarations can have types (modules and packages cannot), so when you
 search by type, you will only get declaration results.
 
 When searching by name, an entry in Pursuit's database is considered to be a
-match if the query is a prefix of its name. For example, "con" matches "const"
-but "cosnt" does not. (This may change in the future.)
+match if the query is a prefix of its name. For example, “con” matches “const”
+but “cosnt” does not. (This may change in the future.)
 
 Currently, documentation comments are not included in the search index. This
-means that, for example, if you search for "Kleisli", there are no results,
+means that, for example, if you search for “Kleisli”, there are no results,
 even though the documentation for [`Star`][] mentions that this type is also
-called "Kleisli" in some contexts. This may also change in the future; see
+called “Kleisli” in some contexts. This may also change in the future; see
 [Pursuit issue #318](https://github.com/purescript/pursuit/issues/318).
 
 [`const`]: https://pursuit.purescript.org/packages/purescript-prelude/docs/Prelude#v:const

--- a/static/help-docs/users.md
+++ b/static/help-docs/users.md
@@ -1,4 +1,4 @@
-## Searching <a name="searching"></a>
+## <a name="searching"></a>Searching
 
 When you use Pursuit's search feature, there are three types of results which
 may come up: declarations, modules, and packages.


### PR DESCRIPTION
@hdgarrood I reviewed your commit 92463dd9b1b3230614ca0b5d01279980dc86d384 and like it a lot. The explanations on searching are clear to me (still a beginner) and the split into user and author help pages is a good idea to provide help for the context that it is needed in.

I added three small commits that all contain a small description in their respective commit message.

1. Move anchors to keep title in viewport
2. Structure help menu with existing styles
3. Use proper typographic quotes

I want to point out that number 3 could be controversial as described in its commit message and you might not want to merge that one (although it would look better).

As for number 2: this is a suggestion of how to use the existing styles better (see screenshot), but if you would want to have a single list that looks more like an index, we'd have to introduce that style (because the spacing in the way you used it before wasn't working so well, I think). To me, number 2 is acceptable and would maybe or maybe not have to be revisited once more topics are added. (In which case you would need to help me with developing the styles in purescript/purescript and then integrate them into purescript/pursuit, I didn't see an easy way right away).

<img width="1090" alt="pursuit-help" src="https://user-images.githubusercontent.com/10811/34384459-95404936-eb1c-11e7-9b83-c214c2b1af9f.png">
