### PR TITLE
DO NOT MERGE: proposal for adding sqlite for caching dependency relations?

### DIFF
--- a/config/models
+++ b/config/models
@@ -1,0 +1,8 @@
+-- By default this file is used by `persistFileWith` in Model.hs (which is imported by Foundation.hs)
+-- Syntax for this file here: https://github.com/yesodweb/persistent/blob/master/docs/Persistent-entity-syntax.md
+
+Package
+    dependent Text
+    version Text
+    dependency Text
+    versionRange Text

--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -1,5 +1,5 @@
 name:              pursuit
-version:           0.6.3
+version:           0.6.4
 cabal-version:     >= 1.8
 build-type:        Simple
 license:           MIT
@@ -32,6 +32,8 @@ library
                      Handler.Utils
                      Import
                      Import.NoFoundation
+                     Model
+                     Utils
                      SearchIndex
                      Settings
                      Settings.EmbedPursuitCss
@@ -129,6 +131,13 @@ library
                  , barrier ==0.1.*
                  , mono-traversable
                  , streaming-commons
+                 , persistent
+                 , persistent-sqlite
+                 , persistent-template
+                 , foreign-store
+                 , esqueleto
+                 , extra
+                 , resource-pool
 
     if flag(dev)
       build-depends: foreign-store
@@ -175,3 +184,4 @@ test-suite test
                  , classy-prelude
                  , classy-prelude-yesod
                  , QuickCheck
+                 , foreign-store

--- a/src/Handler/Caching.hs
+++ b/src/Handler/Caching.hs
@@ -12,6 +12,7 @@ module Handler.Caching
   ) where
 
 import Import
+import Utils (catchDoesNotExist)
 import Data.Version (Version, showVersion)
 import qualified Data.Text.Lazy as LT
 import Text.Blaze.Html.Renderer.Utf8 (renderHtml)

--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -1,6 +1,7 @@
 module Handler.Packages where
 
 import Import
+import Utils
 import Text.Julius (rawJS)
 import Text.Blaze (ToMarkup, toMarkup)
 import qualified Data.Char as Char
@@ -81,6 +82,7 @@ getPackageVersionR (PathPackageName pkgName) (PathVersion version) =
     findPackage pkgName version $ \pkg@D.Package{..} -> do
       moduleList <- renderModuleList pkg
       ereadme    <- tryGetReadme pkg
+      dependents <- getDependents pkgName
       let cacheStatus = either (const NotOkToCache) (const OkToCache) ereadme
       content <- defaultLayout $ do
         setTitle (toHtml (runPackageName pkgName))
@@ -180,7 +182,7 @@ getBuiltinDocsR mnString = do
     _ ->
       defaultLayout404 $ [whamlet|
         <h2>Module not found
-        <p>No such builtin module: #
+        <p>No such builtin: #
           <b>#{mnString}
         |]
 

--- a/src/Handler/Utils.hs
+++ b/src/Handler/Utils.hs
@@ -21,22 +21,6 @@ internalServerError = sendResponseStatus internalServerError500 ("" :: Text)
 getDataDir :: Handler String
 getDataDir = appDataDir . appSettings <$> getYesod
 
--- | Read the file at the given path as a strict ByteString, or return Nothing
--- if no such file exists.
-readFileMay :: FilePath -> IO (Maybe ByteString)
-readFileMay file =
-  catchDoesNotExist (readFile file)
-
-catchDoesNotExist :: IO a -> IO (Maybe a)
-catchDoesNotExist act =
-  catchJust selectDoesNotExist
-            (Just <$> act)
-            (const (return Nothing))
-  where
-  selectDoesNotExist e
-    | isDoesNotExistErrorType (ioeGetErrorType e) = Just ()
-    | otherwise = Nothing
-
 writeFileWithParents :: MonadIO m => FilePath -> ByteString -> m ()
 writeFileWithParents file contents = liftIO $ do
   createDirectoryIfMissing True (takeDirectory file)

--- a/src/Import/NoFoundation.hs
+++ b/src/Import/NoFoundation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Import.NoFoundation
     ( module Import
     , hush
@@ -5,8 +6,11 @@ module Import.NoFoundation
 
 import ClassyPrelude.Yesod   as Import
 import Settings              as Import
+import Model                 as Import
+import Settings              as Import
 import Yesod.Core.Types      as Import (loggerSet)
 import Yesod.Default.Config2 as Import
+import Yesod.Core.Types      as Import (loggerSet)
 import Control.Category      as Import ((>>>), (<<<))
 
 hush :: Either a b -> Maybe b

--- a/src/Model.hs
+++ b/src/Model.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE NoImplicitPrelude          #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+module Model where
+
+
+import ClassyPrelude.Yesod
+import Database.Persist.Quasi
+
+-- You can define all of your database entities in the entities file.
+-- You can find more information on persistent and how to declare entities
+-- at:
+-- http://www.yesodweb.com/book/persistent/
+share [mkPersist sqlSettings, mkMigrate "migrateAll"]
+    $(persistFileWith lowerCaseSettings "config/models")
+

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -8,6 +8,7 @@ module Settings where
 import ClassyPrelude.Yesod
 import System.Environment (lookupEnv)
 import Data.Version
+import Database.Persist.Sqlite     (SqliteConf(..))
 import Language.PureScript.Docs (parseVersion')
 import Language.Haskell.TH.Syntax (Exp, Name, Q)
 import Network.Wai.Handler.Warp (HostPreference)
@@ -32,6 +33,8 @@ data AppSettings = AppSettings
     -- ^ Host/interface the server should bind to.
     , appPort                   :: Int
     -- ^ Port to listen on
+    , appDatabaseConf           :: SqliteConf
+    -- ^ Configuration settings for accessing the database.
     , appIpFromHeader           :: Bool
     -- ^ Get the IP address from the header when logging. Useful when sitting
     -- behind a reverse proxy.
@@ -83,7 +86,7 @@ getAppSettings = do
 
   appAnalytics <- env "GOOGLE_ANALYTICS_CODE"
   appDataDir   <- env "DATA_DIR" .!= "./data"
-
+  appDatabaseConf <- (return SqliteConf { sqlDatabase = "test-sqlite.sqlite3", sqlPoolSize = 10 })
   appGithubAuthToken <- map (GithubAuthToken . fromString) <$> env "GITHUB_AUTH_TOKEN"
   when (isNothing appGithubAuthToken) $
     let message = "No GitHub auth token configured (environment variable is: PURSUIT_GITHUB_AUTH_TOKEN)"

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE EmptyDataDecls             #-}
+{-# LANGUAGE FlexibleInstances          #-}
+{-# LANGUAGE GADTs                      #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE NoImplicitPrelude          #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE TemplateHaskell            #-}
+{-# LANGUAGE TypeFamilies               #-}
+
+module Utils  
+( loadDatabase
+, getAllPackageNamesIO
+, packageDirForIO
+, lookupPackageIO
+, availableVersionsForIO
+, packageVersionFileForIO
+, SomethingMissing(..)
+, readFileMay
+, catchDoesNotExist
+) where
+
+import Import
+import qualified Language.PureScript.Docs as D
+import qualified Data.Pool
+import Data.ByteString (ByteString)
+import Model
+import qualified Data.Aeson as A
+import Database.Persist.Sqlite (createSqlitePool, runSqlPool, sqlDatabase, sqlPoolSize, BaseBackend, SqlBackend, PersistQueryWrite, IsPersistBackend, Filter)
+import Data.Version (showVersion)
+import Data.Either.Extra (Either(..), fromRight')
+import Data.Version (Version, showVersion)
+import Web.Bower.PackageMeta (PackageName, mkPackageName, runPackageName, bowerDependencies, runVersionRange)
+import System.Directory
+  (getDirectoryContents, getModificationTime, doesDirectoryExist)
+
+data SomethingMissing
+  = NoSuchPackage
+    | NoSuchPackageVersion
+    deriving (Show, Eq, Ord)    
+
+catchDoesNotExist :: IO a -> IO (Maybe a)
+catchDoesNotExist act =
+  catchJust selectDoesNotExist
+          (Just <$> act)
+          (const (return Nothing))
+  where
+    selectDoesNotExist e
+      | isDoesNotExistErrorType (ioeGetErrorType e) = Just ()
+      | otherwise = Nothing
+
+-- | Read the file at the given path as a strict ByteString, or return Nothing
+-- if no such file exists.
+readFileMay :: FilePath -> IO (Maybe ByteString)
+readFileMay file =
+  catchDoesNotExist (readFile file)
+
+packageDirForIO :: String -> PackageName -> IO String
+packageDirForIO dir pkgName = do
+  return (dir ++ "/verified/" ++ unpack (runPackageName pkgName))
+
+packageVersionFileForIO :: String -> PackageName -> Version -> IO String
+packageVersionFileForIO dataDir pkgName version = do
+  dir <- packageDirForIO dataDir pkgName
+  return (dir ++ "/" ++ showVersion version ++ ".json")
+
+getAllPackageNamesIO :: String -> IO [PackageName]
+getAllPackageNamesIO dir = do
+  contents <- getDirectoryContents (dir ++ "/verified/")
+  return . sort . rights $ map (mkPackageName . pack) contents
+
+availableVersionsForIO :: String -> PackageName -> IO [Version]
+availableVersionsForIO dataDir pkgName = do
+  dir <- packageDirForIO dataDir pkgName
+  mresult <- catchDoesNotExist $ do
+      files <- getDirectoryContents dir
+      return $ mapMaybe (stripSuffix ".json" >=> D.parseVersion') files
+  return $ fromMaybe [] mresult
+
+lookupPackageIO :: String -> PackageName -> Version -> IO (Either SomethingMissing D.VerifiedPackage)
+lookupPackageIO dataDir pkgName version = do
+  file <- packageVersionFileForIO dataDir pkgName version
+  mcontents <- readFileMay file
+  case mcontents of
+      Just contents -> case A.eitherDecodeStrict contents of
+          -- TODO: this should be a corect error
+          Left _ -> return $ Left NoSuchPackage
+          Right pkg -> return $ Right pkg
+      Nothing -> do
+          -- Work out whether there's no such package or just no such version
+          dir <- packageDirForIO dataDir pkgName
+          exists <- doesDirectoryExist dir
+          return $ Left $ if exists then NoSuchPackageVersion else NoSuchPackage    
+
+-- | This function loads all the dependencies into the sqlite database
+loadDatabase :: 
+  (BaseBackend backend ~ SqlBackend, PersistQueryWrite backend, IsPersistBackend backend) 
+  => String -> Data.Pool.Pool backend -> IO ()
+loadDatabase dir pool = do
+  runSqlPool (deleteWhere ([] :: [Filter Package])) pool
+  packageNames <- getAllPackageNamesIO dir
+  forM_ packageNames $ \packageName -> do
+    versions <- availableVersionsForIO dir packageName
+    forM_ versions $ \version -> do
+        eitherPackage <- lookupPackageIO dir packageName version
+        case eitherPackage of
+            -- TODO: Should I at least log the error value?
+            Left _ -> return ()
+            Right pkg -> forM_ (getDepList pkg) $ \(pkgDep, versionRange) -> do
+                -- TODO: Should I do something with the return value?
+                _ <-insertPkgDep 
+                  (runPackageName packageName) 
+                  (pack (showVersion version))
+                  pkgDep
+                  versionRange
+                return ()
+  where
+    insertPkgDep pkg ver dep depver = runSqlPool (insert (Package pkg ver dep depver)) pool
+    getDepList p = map (\(x,y) -> (runPackageName x,runVersionRange y)) $ bowerDependencies $ D.pkgMeta $ p
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,5 @@
 resolver: nightly-2017-09-10
+# resolver: lts-11.10
 flags:
   pursuit:
     dev: true

--- a/templates/packageVersion.hamlet
+++ b/templates/packageVersion.hamlet
@@ -32,3 +32,11 @@
           <div .deplink>
             <a .deplink__link href=@{packageNameRoute depPkg}>#{runPackageName depPkg}
             <span .deplink__version>#{renderVersionRange versionRange}
+  <dl .grouped-list>
+      <dt .grouped-list__title>Dependents
+      $if null dependents
+        <dd .grouped-list__item>No depents
+      $else
+        $forall pkgDepns <- dependents
+          <dd .grouped-list__item>
+            <div .deplink>#{runPackageName pkgDepns}


### PR DESCRIPTION
Hi!

First, a disclaimer. This PR probably is quite ugly and unfinished piece of code that I don't expect in any form to be merged. I started working on it ~a week ago, after I tried naively implement reverse-dependency listing and realized that for site to be responsive there would need to be some sort of cache of the package-relation.

If i.e. @hdgarrood would think this approach might have some merit, I would really like to work with somebody to finish this into an actually merge-able piece of code.

If it would be too much work, I have no problem closing this PR and let someone else take a stab at #292 

So the approach in this code is:
* bring in Persistent Sqlite as a database backend
* on the start of the application, load all of the packag versions into Persistent
* On Package display, run an Esqueletto query to get the reverse deps

Right now:
* it adds ~3 minutes to startup
* there are no database updates on create/remove/update of the package (as they should)
* the dependent packages don't take version-ranges into account (as they should)
* the dependent packages are not cross-linked (as they should)
* there are some hard-coded values
* there are some copy-pasted util functions
* I am really unsure about the code-(style/quality), but at least it did compile on my machine :smile: 

So, what do you think?