### PR TITLE
Don't render links to non-purescript dependencies

### DIFF
--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -5,6 +5,7 @@ import Text.Julius (rawJS)
 import Text.Blaze (ToMarkup, toMarkup)
 import qualified Data.Char as Char
 import Data.Version
+import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Language.PureScript.Docs as D
 import Web.Bower.PackageMeta (PackageName, runPackageName, bowerDependencies, bowerLicense)
@@ -87,6 +88,10 @@ getPackageVersionR (PathPackageName pkgName) (PathVersion version) =
         let dependencies = bowerDependencies pkgMeta
         $(widgetFile "packageVersion")
       return (cacheStatus, content)
+
+isPurescriptPackage :: PackageName -> Bool
+isPurescriptPackage pkgName =
+    "purescript-" `T.isPrefixOf` runPackageName pkgName
 
 getPackageIndexR :: Handler TypedContent
 getPackageIndexR =

--- a/templates/packageVersion.hamlet
+++ b/templates/packageVersion.hamlet
@@ -30,5 +30,8 @@
       $forall (depPkg, versionRange) <- dependencies
         <dd .grouped-list__item>
           <div .deplink>
-            <a .deplink__link href=@{packageNameRoute depPkg}>#{runPackageName depPkg}
+            $if isPurescriptPackage depPkg
+              <a .deplink__link href=@{packageNameRoute depPkg}>#{runPackageName depPkg}
+            $else
+              <a .deplink__link href="https://libraries.io/bower/#{runPackageName depPkg}">#{runPackageName depPkg}
             <span .deplink__version>#{renderVersionRange versionRange}


### PR DESCRIPTION
When a purescript package has non-purescript dependency (e.g. purescript-d3 depends on d3 js library), there is a link rendered on it's page in the "dependencies" section, which takes you to error page saying: "No package named d3 exists in the database."

I wrote a selenium script and scraped a locally running pursuit instance to check how many packages are affected by this problem. Here are all the occurrences of this issue on https://pursuit.purescript.org/ which I found that way:

- [purescript-clappr](https://pursuit.purescript.org/packages/purescript-clappr) depends on clappr
- [purescript-d3](https://pursuit.purescript.org/packages/purescript-d3) depends on d3
- [purescript-enzyme](https://pursuit.purescript.org/packages/purescript-enzyme) depends on react
- [purescript-generic-graphviz](https://pursuit.purescript.org/packages/purescript-generic-graphviz) depends on viz.js
- [purescript-graphviz](https://pursuit.purescript.org/packages/purescript-graphviz) depends on viz.js
- [purescript-halogen-leaflet](https://pursuit.purescript.org/packages/purescript-halogen-leaflet) depends on leaflet
- [purescript-leaflet-tdammers](https://pursuit.purescript.org/packages/purescript-leaflet-tdammers) depends on leaflet
- [purescript-mathbox](https://pursuit.purescript.org/packages/purescript-mathbox) depends on mathbox
- [purescript-mustache](https://pursuit.purescript.org/packages/purescript-mustache) depends on mustache
- [purescript-oak](https://pursuit.purescript.org/packages/purescript-oak) depends on virtual-dom
- [purescript-pux-clappr](https://pursuit.purescript.org/packages/purescript-pux-clappr) depends on fast-deep-equal
- [purescript-simple-moment](https://pursuit.purescript.org/packages/purescript-simple-moment) depends on moment
- [purescript-vexflow](https://pursuit.purescript.org/packages/purescript-vexflow) depends on vexflow
- [purescript-webcomponents](https://pursuit.purescript.org/packages/purescript-webcomponents) depends on webcomponentsjs

It's easy to detect non-purescript dependencies (they don't have "purescript-" prefix).
So instead of rendering links that lead to "not found" page we can instead:
1. Just render the dependency name as text, with some additional explanation. That's the change proposed in this PR which does the following for non-PS deps:

![screenshot from 2019-01-29 12-46-32](https://user-images.githubusercontent.com/2716069/51906897-906b6e80-23c5-11e9-9fef-8139ae4ccc95.png)



2. Another option would be to render a link to some external website with javascript dependencies (e.g https://libraries.io/npm/d3). I'm not that familiar with the JS ecosystem, so I don't know if such links would be reliable enough. That's why I went for simpler option 1. What do you think?