### PR TITLE
Provide Markdown text in the `text` field for json search results

### DIFF
--- a/src/Handler/Search.hs
+++ b/src/Handler/Search.hs
@@ -189,7 +189,7 @@ searchResultToJSON result@SearchResult{..} = do
     object [ "package" .= pkg
            , "version" .= showVersion version
            , "markup" .= BlazeT.renderMarkup html
-           , "text" .= BlazeT.renderMarkup (Blaze.contents html)
+           , "text" .= srComments
            , "info" .= toJSON srInfo
            , "url" .= url
            ]


### PR DESCRIPTION
Fixes #171

Now:
```
$ curl http://localhost:3000/search?q=Map -H 'Accept: application/json' 2>/dev/null | jq .[1]
{
  "text": "`Map k v` represents maps from keys of type `k` to values of type `v`.\n",
  "markup": "<p><code>Map k v</code> represents maps from keys of type <code>k</code> to values of type <code>v</code>.</p>\n",
  "url": "http://localhost:3000/packages/purescript-ordered-collections/1.4.0/docs/Data.Map.Internal#t:Map",
  "version": "1.4.0",
  "package": "purescript-ordered-collections",
  "info": {
    "typeOrValue": "TypeLevel",
    "module": "Data.Map.Internal",
    "typeText": null,
    "title": "Map",
    "type": "declaration"
  }
}
```