### PR TITLE
Treat variables in type queries same as type wildcards

### DIFF
--- a/src/SearchIndex.hs
+++ b/src/SearchIndex.hs
@@ -398,6 +398,7 @@ compareTypes type1 type2 =
   go :: D.Type' -> D.Type' -> WriterT [(Text, Text)] Maybe Int
   go (P.TypeVar _ v1) (P.TypeVar _ v2) = tell [(v1, v2)] *> pure 0
   go t (P.TypeVar _ _) = pure (1 + typeComplexity t)
+  go (P.TypeVar _ _) t = pure (typeComplexity t)
   go (P.TypeLevelString _ s1) (P.TypeLevelString _ s2) | s1 == s2 = pure 0
   go (P.TypeWildcard _ _) t = pure (typeComplexity t)
   go (P.TypeConstructor _ q1) (P.TypeConstructor _ q2) | compareQual q1 q2 = pure 0

--- a/src/SearchIndex.hs
+++ b/src/SearchIndex.hs
@@ -381,12 +381,12 @@ tryStripPrefix pre s = fromMaybe s (T.stripPrefix pre s)
 -- let compare s1 s2 = compareTypes <$> parseType s2 <*> parseType s2
 --
 -- >>> compare "a" "Int"
--- Just Nothing
+-- Just (Just 0)
 -- >>> compare "Int" "a"
 -- Just (Just 1)
 --
--- (The idea here being it's ok to show a more general version of the query,
--- but usually not helpful to show a more concrete version of it.)
+-- (The idea here being it's preferred to show a more concrete version of the
+-- query, rather than showing a more general version of it.)
 --
 compareTypes :: D.Type' -> D.Type' -> Maybe Int
 compareTypes type1 type2 =


### PR DESCRIPTION
fix #395 