### PR TITLE
Single-command deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ data
 static/tmp/
 license-generator/tmp/
 /.stack-work/
+bundle/
+pursuit.tar.gz

--- a/deploy/pursuit.service
+++ b/deploy/pursuit.service
@@ -4,7 +4,7 @@ Description=Web service for hosting of PureScript API documentation
 [Service]
 Type=simple
 User=www-data
-ExecStart=/var/www/pursuit/pursuit +RTS -N1 -A128m -M1.5G -RTS
+ExecStart=/usr/local/bin/pursuit +RTS -N1 -A128m -M1.5G -RTS
 Restart=always
 RestartSec=5s
 Environment="PURSUIT_APPROOT=https://pursuit.purescript.org"

--- a/deploy/remote.sh
+++ b/deploy/remote.sh
@@ -1,0 +1,63 @@
+#! /usr/bin/env bash
+
+set -ex
+
+# This script should be run on the Pursuit server to deploy a new version. It
+# does not attempt to take care of any of the following:
+#
+# - configuration of secrets/credentials
+# - data migrations,
+# - nginx SSL configuration,
+#
+# so whenever any of these are needed, they must be done manually.
+
+if [ $(id --user) -ne 0 ]
+then
+  echo >&2 "This script must be run as root"
+  exit 1
+fi
+
+pursuit_version="$1"
+
+if [ "$pursuit_version" = "" ]
+then
+  echo >&2 "Need to provide a version"
+  exit 1
+fi
+
+download_url="https://github.com/purescript/pursuit/releases/download/${pursuit_version}/pursuit.tar.gz"
+
+echo "[$(date)] $0: starting pursuit install"
+
+# set up directories for deploying into
+if [ ! -d /var/www/pursuit ]; then
+  mkdir -p /var/www/pursuit
+  chown -R www-data:www-data /var/www/pursuit
+fi
+
+# clone database files if not present
+if [ ! -d /var/www/pursuit/data/verified ]; then
+  sudo -u www-data sh -c 'cd /var/www/pursuit && git clone https://github.com/purescript/pursuit-backups data/verified'
+fi
+
+# download release
+tmpdir="$(sudo -u www-data mktemp -d)"
+pushd "$tmpdir"
+sudo -u www-data wget "$download_url"
+sudo -u www-data tar xzf pursuit.tar.gz -C /var/www/pursuit --overwrite
+# We install the binary to a location outside of /var/www/pursuit so that we
+# can extract tar.gz files into /var/www/pursuit safely in future deploys.
+install /var/www/pursuit/pursuit /usr/local/bin/pursuit
+popd
+rm -r "$tmpdir"
+
+# install nginx config
+cp /var/www/pursuit/deploy/nginx.conf /etc/nginx/sites-enabled/pursuit.conf
+systemctl reload nginx
+
+# install systemd service confing
+cp /var/www/pursuit/deploy/pursuit.service /etc/systemd/system/pursuit.service
+systemctl daemon-reload
+systemctl restart pursuit.service
+
+echo "[$(date)] $0: done pursuit install"

--- a/deploy/run.sh
+++ b/deploy/run.sh
@@ -2,56 +2,16 @@
 
 set -ex
 
-# This script installs or updates the Pursuit server. It does not attempt to
-# take care of data migrations; where they are needed, they must be done
-# manually.
+# This script can be run to deploy a new version of Pursuit.
 
-if [ $(id --user) -ne 0 ]
+pursuit_version="$1"
+
+if [ "$pursuit_version" = "" ]
 then
-  echo >&2 "This script must be run as root"
+  echo >&2 "Need to provide a version"
   exit 1
 fi
 
-# Hardcoded for now
-pursuit_github_auth_token="placeholder"
-pursuit_db_backup_ssh_key="placeholder"
-pursuit_version="v0.7.3"
-
-download_url="https://github.com/purescript/pursuit/releases/download/${pursuit_version}/pursuit.tar.gz"
-
-echo "[$(date)] $0: starting pursuit install"
-
-# set up directories for deploying into
-if [ ! -d /var/www/pursuit ]; then
-  mkdir -p /var/www/pursuit
-  chown -R www-data:www-data /var/www/pursuit
-fi
-
-# clone database files if not present
-if [ ! -d /var/www/pursuit/data/verified ]; then
-  sudo -u www-data sh -c 'cd /var/www/pursuit && git clone https://github.com/purescript/pursuit-backups data/verified'
-fi
-
-# create diffie-helman parameters (for TLS) if not present
-if [ ! -f /etc/nginx/ssl_dhparam ]; then
-  openssl dhparam 4096 > /etc/nginx/ssl_dhparam
-fi
-
-# download release
-tmpdir="$(sudo -u www-data mktemp -d)"
-pushd "$tmpdir"
-sudo -u www-data wget "$download_url"
-sudo -u www-data tar xzf pursuit.tar.gz -C /var/www/pursuit
-popd
-rm -r "$tmpdir"
-
-# install nginx config
-cp /var/www/pursuit/deploy/nginx.conf /etc/nginx/sites-enabled/pursuit.conf
-systemctl reload nginx
-
-# install systemd service confing
-cp /var/www/pursuit/deploy/pursuit.service /etc/systemd/system/pursuit.service
-systemctl daemon-reload
-systemctl restart pursuit.service
-
-echo "[$(date)] $0: done pursuit install"
+deploy_script="deploy-pursuit.sh"
+scp deploy/remote.sh "root@pursuit.purescript.org:${deploy_script}"
+ssh root@pursuit.purescript.org "bash ${deploy_script} ${pursuit_version}"


### PR DESCRIPTION
This commit tweaks the deploy scripts so that once a tagged version of
Pursuit has been built on Travis CI and uploaded to GH releases as a
tar.gz bundle, it can be deployed simply by running e.g.

    $ deploy/run.sh v0.7.3

at the command line. This brings us one step closer to auto-deployment.

Specifically, this commit does the following:

- renames the script deploy/run.sh to deploy/remote.sh to better
  indicate that it is intended to be run on the remote server
- updates the deploy script and the systemd service file so that the
  pursuit binary is installed to /usr/local/bin and run from there.
  This is necessary because `tar` refuses to write to a running
  executable file when extracting; we have to use `install` instead.
- clarifies what the deploy script is and isn't responsible for in
  comments