### PR TITLE
Update Pursuit for PureScript 0.14

### DIFF
--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -103,6 +103,7 @@ library
                  , vector
                  , time
                  , purescript
+                 , purescript-cst
                  , bower-json
                  , blaze-builder
                  , blaze-markup

--- a/src/Foundation.hs
+++ b/src/Foundation.hs
@@ -5,6 +5,7 @@
 module Foundation where
 
 import Import.NoFoundation
+import Language.PureScript.CoreFn.FromJSON (parseVersion')
 import Text.Read (readsPrec)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
@@ -44,7 +45,7 @@ newtype PathVersion =
 
 instance PathPiece PathVersion where
   toPathPiece = toPathPiece . showVersion . runPathVersion
-  fromPathPiece = fmap PathVersion . D.parseVersion' . T.unpack
+  fromPathPiece = fmap PathVersion . parseVersion' . T.unpack
 
 -- | A base64 encoded string.
 newtype VerificationKey =

--- a/src/Handler/Database.hs
+++ b/src/Handler/Database.hs
@@ -13,6 +13,7 @@ module Handler.Database
   ) where
 
 import Import
+import Language.PureScript.CoreFn.FromJSON (parseVersion')
 import qualified Data.Aeson as A
 import qualified Data.NonNull as NN
 import qualified Data.Text as T
@@ -79,7 +80,7 @@ availableVersionsFor pkgName = do
   dir <- packageDirFor pkgName
   mresult <- liftIO $ catchDoesNotExist $ do
     files <- getDirectoryContents dir
-    return $ mapMaybe (stripSuffix ".json" >=> D.parseVersion') files
+    return $ mapMaybe (stripSuffix ".json" >=> parseVersion') files
   return $ fromMaybe [] mresult
 
 getPackageModificationTime :: PackageName -> Handler UTCTime

--- a/src/Handler/Packages.hs
+++ b/src/Handler/Packages.hs
@@ -7,6 +7,7 @@ import qualified Data.Char as Char
 import Data.Version
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
+import Language.PureScript.CoreFn.FromJSON (parseVersion')
 import qualified Language.PureScript.Docs as D
 import Web.Bower.PackageMeta (PackageName, runPackageName, bowerDependencies, bowerLicense)
 import qualified Data.HashMap.Strict as HashMap
@@ -263,7 +264,7 @@ displayJsonError value e = case e of
     toObject
     >=> HashMap.lookup "compilerVersion"
     >=> toString
-    >=> (D.parseVersion' . unpack)
+    >=> (parseVersion' . unpack)
 
   toObject json =
     case json of

--- a/src/SearchIndex.hs
+++ b/src/SearchIndex.hs
@@ -277,6 +277,8 @@ extractChildDeclarationType declTitle declInfo cdeclInfo =
             , P.constraintArgs = map (P.TypeVar () . fst) args
             , P.constraintData = Nothing
             , P.constraintAnn = ()
+              -- TODO: Verify that defaulting to `kindType` works
+            , P.constraintKindArgs = map (fromMaybe (P.kindType $> ()) . snd) args
             }
         in
           Just (addConstraint constraint ty)
@@ -470,7 +472,8 @@ compareQual (P.Qualified _ a1) (P.Qualified _ a2) = a1 == a2
 
 runParser :: CST.Parser a -> Text -> Maybe a
 runParser p =
-  hush
+  fmap snd
+    . hush
     . CST.runTokenParser (p <* CSTM.token CST.TokEof)
     . CST.lexTopLevel
 

--- a/src/Settings.hs
+++ b/src/Settings.hs
@@ -8,7 +8,7 @@ module Settings where
 import ClassyPrelude.Yesod
 import System.Environment (lookupEnv)
 import Data.Version
-import Language.PureScript.Docs (parseVersion')
+import Language.PureScript.CoreFn.FromJSON (parseVersion')
 import Language.Haskell.TH.Syntax (Exp, Name, Q)
 import Network.Wai.Handler.Warp (HostPreference)
 import Yesod.Default.Util (WidgetFileSettings, widgetFileNoReload,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,16 +1,28 @@
 resolver: lts-13.26
+# Resolves hjsmin requiring language-javascript ==0.6, while the purescript
+# compiler requires language-javascript ==0.7.
+allow-newer: true 
 packages:
 - '.'
 extra-deps:
 - bytestring-trie-0.2.5.0
+- cborg-0.2.2.0
 - connection-0.3.1
 - happy-1.19.9
-- language-javascript-0.6.0.13
+- language-javascript-0.7.0.0
 - network-3.0.1.1
-- purescript-0.13.3
+- ../purescript
+- ../purescript/lib/purescript-ast
+- ../purescript/lib/purescript-cst
+- serialise-0.2.2.0
 - socks-0.6.0
+- these-1.0.1
+- semialign-1
 flags:
   pursuit:
     dev: true
   aeson-pretty:
     lib-only: true
+  these:
+    assoc: false
+    quickcheck: false

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,13 +11,17 @@ extra-deps:
 - happy-1.19.9
 - language-javascript-0.7.0.0
 - network-3.0.1.1
-- ../purescript
-- ../purescript/lib/purescript-ast
-- ../purescript/lib/purescript-cst
 - serialise-0.2.2.0
 - socks-0.6.0
 - these-1.0.1
 - semialign-1
+# purescript 0.14.0-rc4
+- github: purescript/purescript
+  commit: 8663d00a27c2c36e229f3d2f98358e660c297335
+  subdirs:
+    - .
+    - lib/purescript-ast
+    - lib/purescript-cst
 flags:
   pursuit:
     dev: true

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -12,6 +12,13 @@ packages:
   original:
     hackage: bytestring-trie-0.2.5.0
 - completed:
+    hackage: cborg-0.2.2.0@sha256:83b644d2634991403e60a2766b0fcddb3eacf8acfed92f568a90311ed1ef779e,4953
+    pantry-tree:
+      size: 2559
+      sha256: 8ebe0d8b2d71f9a938ed73143e4c7ba068621fd2c83ff7d0c75fc940ab5fe163
+  original:
+    hackage: cborg-0.2.2.0
+- completed:
     hackage: connection-0.3.1@sha256:65da1c055610095733bcd228d85dff80804b23a5d18fede994a0f9fcd1b0c121,1554
     pantry-tree:
       size: 386
@@ -26,12 +33,12 @@ packages:
   original:
     hackage: happy-1.19.9
 - completed:
-    hackage: language-javascript-0.6.0.13@sha256:06238479380c78a7e0fa19da6576fb1750f44c25235c942fd33af6f3969fef85,3899
+    hackage: language-javascript-0.7.0.0@sha256:3eab0262b8ac5621936a4beab6a0f97d0e00a63455a8b0e3ac1547b4088dae7d,3898
     pantry-tree:
-      size: 2242
-      sha256: 233def9aae1c800a2c2d735ae1223bcdae90be2a23f08b2960c070b594964af5
+      size: 2244
+      sha256: b0f28d836cb3fbde203fd7318a896c3a20acd8653a905e1950ae2d9a64bccebf
   original:
-    hackage: language-javascript-0.6.0.13
+    hackage: language-javascript-0.7.0.0
 - completed:
     hackage: network-3.0.1.1@sha256:1a251b790ea98b6f7433f677958f921950780ba6f143d61ba8c0e3f7a9879097,4074
     pantry-tree:
@@ -40,12 +47,12 @@ packages:
   original:
     hackage: network-3.0.1.1
 - completed:
-    hackage: purescript-0.13.3@sha256:662f01c05be54ad8c9e35475c38f55aca2988705f261b67a71d6180957239ad1,61044
+    hackage: serialise-0.2.2.0@sha256:6e8b89f437009ab30297a57de1a4bf2e3da5e5a086b96bf5cc278bdb7178f097,8356
     pantry-tree:
-      size: 94327
-      sha256: b00dfdbfc1b60c381bbc92d8782cfb4b9dab8cf02e246b3d60aac7f024830ead
+      size: 4056
+      sha256: 97702981cdfe830fca6d258341b9773272400e475165689548f56da83eff2778
   original:
-    hackage: purescript-0.13.3
+    hackage: serialise-0.2.2.0
 - completed:
     hackage: socks-0.6.0@sha256:a058ee6b66da40a2365efcf44b4c06c96e58a23b150bd3f3d0f9f5cadc33f728,1318
     pantry-tree:
@@ -53,6 +60,20 @@ packages:
       sha256: 036f8eefaf2a473554c733ca838373b49c1b686eee4a8180741b8123d788dbc5
   original:
     hackage: socks-0.6.0
+- completed:
+    hackage: these-1.0.1@sha256:58dba2446b57dde711c5e7f63910d18bc28b9a5831a89772986bb184a3e7851b,3266
+    pantry-tree:
+      size: 351
+      sha256: dd785882a522b6c76ee97fdd5e0e8cbca15b2fc951985bbecc76d0dd6e456aae
+  original:
+    hackage: these-1.0.1
+- completed:
+    hackage: semialign-1@sha256:f11b3d8d0f31a3556061ec0fb515575646d162f12c5b25a0f07c92679db7d862,2433
+    pantry-tree:
+      size: 466
+      sha256: e67b833b94b7fa23afbf7088833a38596cf35a2b93635604dd9e49d0389360fe
+  original:
+    hackage: semialign-1
 snapshots:
 - completed:
     size: 499889


### PR DESCRIPTION
This PR updates Pursuit to compile with PureScript 0.14. There are still some checks that need to happen:

- [x] Verify that 0.13.x compilers can successfully upload to this version of Pursuit
- [x] Verify that 0.14.x compilers can successfully upload to this version of Pursuit
- [x] Verify that defaulting to `kindType` in `extractChildDeclarationType` doesn't break anything
- [x] Verify the [current Pursuit database](https://github.com/purescript/pursuit-backups) can be understood by this version of Pursuit
