### PR TITLE
Default constraintKindArgs to an empty list

### DIFF
--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -1,5 +1,5 @@
 name:              pursuit
-version:           0.8.1
+version:           0.8.2
 cabal-version:     >= 1.8
 build-type:        Simple
 license:           MIT

--- a/src/SearchIndex.hs
+++ b/src/SearchIndex.hs
@@ -277,7 +277,7 @@ extractChildDeclarationType declTitle declInfo cdeclInfo =
             , P.constraintArgs = map (P.TypeVar () . fst) args
             , P.constraintData = Nothing
             , P.constraintAnn = ()
-            , P.constraintKindArgs = fold $ traverse snd args
+            , P.constraintKindArgs = []
             }
         in
           Just (addConstraint constraint ty)

--- a/src/SearchIndex.hs
+++ b/src/SearchIndex.hs
@@ -277,8 +277,7 @@ extractChildDeclarationType declTitle declInfo cdeclInfo =
             , P.constraintArgs = map (P.TypeVar () . fst) args
             , P.constraintData = Nothing
             , P.constraintAnn = ()
-              -- TODO: Verify that defaulting to `kindType` works
-            , P.constraintKindArgs = map (fromMaybe (P.kindType $> ()) . snd) args
+            , P.constraintKindArgs = fold $ traverse snd args
             }
         in
           Just (addConstraint constraint ty)


### PR DESCRIPTION
In `constraintKindArgs` we previously defaulted any missing kind annotation to `kindType`, which ended up filling missing kind annotations with an application `@Type`. This is now set to an empty list.

I've also bumped the version in the .cabal file so this can be released. I can do that in a separate commit, though, if desired.