### PR TITLE
Add docs for deploying using new compiler release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 After making a new compiler release, do the following to redeploy Pursuit using the new compiler.
 
 1. Submit a PR with the following changes:
+    - In `pursuit.cabal`, update the version to the next release using the `X.X.X` version schema.
     - In `stack.yaml`, update `purescript` (and possibly `purescript-cst`) to use its new version.
 1. Once the PR is merged, create a new GitHub tagged release using `vX.X.X` as the version schema. The release will trigger a GitHub Actions build.
 1. Wait for the GitHub Actions build to finish (it builds the assets)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+# Release
+
+## Instructions for Redeploying Pursuit
+
+After making a new compiler release, do the following to redeploy Pursuit using the new compiler.
+
+1. Submit a PR with the following changes:
+    - In `stack.yaml`, update `purescript` (and possibly `purescript-cst`) to use its new version.
+1. Once the PR is merged, create a new GitHub tagged release using `vX.X.X` as the version schema. The release will trigger a GitHub Actions build.
+1. Wait for the GitHub Actions build to finish (it builds the assets)
+1. Run `./deploy/run.sh vX.X.X`, replacing `X.X.X` with the version you created.


### PR DESCRIPTION
Adds docs to help us remember exactly what needs to be done to redeploy Pursuit.