### PR TITLE
Update PureScript to 0.15.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ the most up-to-date version of this file.
 
 ## Unreleased
 
+## v0.9.2
+
+- Update `purescript` to `0.15.1` (@JordanMartinez)
+
+  This version of the compiler corrects and cleans up
+  some of the docs for the builtin `Prim` module.
+
 ## v0.9.1
 
 - Fix typo in `ncu` command on `authors.md` page (@kRITZCREEK)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ the most up-to-date version of this file.
 
 ## v0.9.2
 
-- Update `purescript` to `0.15.1` (@JordanMartinez)
+- Update `purescript` to `0.15.2` (@JordanMartinez)
 
   This version of the compiler corrects and cleans up
   some of the docs for the builtin `Prim` module.

--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -102,7 +102,7 @@ library
                  , containers
                  , vector
                  , time
-                 , purescript == 0.15.1
+                 , purescript == 0.15.2
                  , bower-json
                  , blaze-builder
                  , blaze-markup

--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -1,5 +1,5 @@
 name:              pursuit
-version:           0.9.1
+version:           0.9.2
 cabal-version:     >= 1.8
 build-type:        Simple
 license:           MIT

--- a/pursuit.cabal
+++ b/pursuit.cabal
@@ -102,7 +102,7 @@ library
                  , containers
                  , vector
                  , time
-                 , purescript == 0.15.0
+                 , purescript == 0.15.1
                  , bower-json
                  , blaze-builder
                  , blaze-markup

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ extra-deps:
   - bytestring-trie-0.2.5.0
   - classy-prelude-yesod-1.5.0
   - language-javascript-0.7.0.0
-  - purescript-0.15.0
+  - purescript-0.15.2
   - monoidal-containers-0.6.2.0
   - process-1.6.13.1
   - Cabal-3.2.1.0


### PR DESCRIPTION
I'm opening this PR up, so it's easier to redeploy Pursuit once `0.15.1` gets released.

When `0.15.1` is released, we'll need to rerun CI.