### PR TITLE
Update nginx max body size to 10m

### DIFF
--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -25,6 +25,11 @@ server {
 
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
+    
+    # Some package resolutions (web-html, halogen, etc.) exceed the 1m default
+    # size set by nginx, so we expand that limit.
+    # https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
+    client_max_body_size 10m;
 
     # SSL configuration
     # based on https://ssl-config.mozilla.org/


### PR DESCRIPTION
As seen [in this failed workflow on the registry](https://github.com/purescript/registry/actions/runs/3088187056/jobs/4994371593), some package resolutions exceed the 1m default body size imposed by nginx, and so this PR raises that limit to be 10m instead.

Relates to #189, #215, #227, and so on – this has been an issue for some time.