### PR TITLE
RELEASE: cabal build not necessary

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,10 +9,7 @@ After making a new compiler release, do the following to redeploy Pursuit using 
         - update the `version` field to the next release using the `X.X.X` version schema.
         - update the `purescript` version to the next release (e.g. `== 0.15.0`)
     - In `stack.yaml`, update `purescript` to use its new version.
-    - Update the `LICENSE` file by doing the following:
-        - Run `cabal build`
-          - This is needed so that [`cabal-plan`](https://github.com/haskell-hvr/cabal-plan) can generate our licenses
-        - Run `./license-generator/generate`
+    - Update the `LICENSE` file by running `./license-generator/generate` which executes [`cabal-plan`](https://github.com/haskell-hvr/cabal-plan)
     - Update the CHANGELOG.md to include a new section for the new release
 2. Once the PR is merged, create a new GitHub tagged release using `vX.X.X` as the version schema. The release will trigger a GitHub Actions build.
 3. Wait for the GitHub Actions build to finish (it builds the assets)


### PR DESCRIPTION
Removed cabal build instruction since it was added to the script.

https://github.com/purescript/pursuit/blob/d0e2c5a514ec7bb6a8fee5bcd6357ef9f0036014/license-generator/generate#L22