### PR TITLE
Update pursuit.service to max heap size of 3.5GB

### DIFF
--- a/deploy/pursuit.service
+++ b/deploy/pursuit.service
@@ -4,7 +4,7 @@ Description=Web service for hosting of PureScript API documentation
 [Service]
 Type=simple
 User=www-data
-ExecStart=/usr/local/bin/pursuit +RTS -N1 -A128m -M1.5G -RTS
+ExecStart=/usr/local/bin/pursuit +RTS -N1 -A128m -M3.5G -RTS
 Restart=always
 RestartSec=5s
 Environment="PURSUIT_APPROOT=https://pursuit.purescript.org"


### PR DESCRIPTION
The Pursuit server used to have 2GB of memory. We've been seeing regular crashes as the server runs out of memory. We've upgraded to a 4GB server and need to bump this compiler flag to take advantage of the increased memory available — otherwise we see errors like this one:

```console
$ journalctl -tf pursuit.service
Dec 06 17:08:16 pursuit pursuit[1133]: Starting in production mode
Dec 06 17:08:16 pursuit pursuit[1133]: pursuit: Heap exhausted;
Dec 06 17:08:16 pursuit pursuit[1133]: pursuit: Current maximum heap size is 1610612736 bytes (1536 MB).
Dec 06 17:08:16 pursuit pursuit[1133]: pursuit: Use `+RTS -M<size>' to increase it.
```