### PR TITLE
Update changelog for deprecation marker cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,16 @@ the most up-to-date version of this file.
   directory directly. Responses are now written to a temporary file and
   renamed into place, which is atomic; the same flood now returns no errors.
 
+- Avoid decoding the latest package version just to render deprecation badges
+  on old-version package pages (@thomashoneyman)
+
+  Package and module documentation pages display a deprecated badge when the
+  latest package version is marked with the `pursuit-deprecated` keyword.
+  Old-version pages previously decoded both the requested version and the
+  latest version's full docs JSON to compute that one boolean. They now cache
+  a tiny version-stamped deprecation marker per package, so after the first
+  marker miss these renders decode only the requested package version.
+
 ## v0.9.11
 
 - Serialise decoding of large package files (@thomashoneyman)


### PR DESCRIPTION
## Summary
- document the deprecation marker cache added for old-version package pages

## Verification
- git diff --check